### PR TITLE
metadata-probability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Metadata
+# BigScience Metadata
 
-Experiments on including metadata such as URLs, timestamps, website descriptions and HTML tags during pretraining.
+This repository contains code for including metadata such as URLs, timestamps, website descriptions and HTML tags during language model pretraining.
 
 ## Usage
 
@@ -8,11 +8,40 @@ Experiments on including metadata such as URLs, timestamps, website descriptions
 accelerate launch --fp16 train.py max_train_steps=100 num_eval=1 data_config.per_device_eval_batch_size=4
 ```
 
-## Metadata format
+## Metadata Format
+
+This script expects metadata to be in [JSON lines (.jsonl)](https://jsonlines.org/) format. Each JSON line is required to have the following fields:
+
+- ``text``: The actual input text.
+- ``metadata``: A list of metadata associated with the given text.
+
+The script supports two different kinds of metadata: *global* metadata, which applies to the whole text, and *local* metadata, which applies only to parts of it.
+
+### Global Metadata
+
+Global metadata is required to have the following fields:
+
+- ``key``: A unique key to identify this kind of metadata (e.g., ``url`` or ``timestamp``).
+- ``type``: This must be set to ``global``.
+- ``value``: The actual value associated with this metadata instance (e.g., an actual URL or timestamp).
+
+### Local Metadata
+
+Local metadata is required to have the following fields:
+
+- ``key``: A unique key to identify this kind of metadata (e.g., ``entity`` or ``html``).
+- ``type``: This must be set to ``local``.
+- ``char_start_idx``: The index of the first character in ``text`` that is associated with this metadata instance.
+- ``char_end_idx``: The index of the first character in ``text`` that is **not** associated with this metadata instance.
+- ``value``: The actual value associated with this metadata instance (e.g., an entity name or HTML tag).
+
+### Example
+
+Below is a valid input example consisting of a text with two global metadata instances (``url`` and ``timestamp``) and one local metadata instance (``entity``).
+Note that this entire input should be in *a single line* in the actual dataset.
 
 ```javascript
 {
-    "id": "ABC",
     "text": "It was a brilliant first round. You have to break down the Cuban's rhythm you can't let them get into rhythm. The risk with that is Yafai has got to go him.",
     "metadata": [
         {

--- a/metadata/input_pipeline.py
+++ b/metadata/input_pipeline.py
@@ -7,11 +7,14 @@ class DataConfig:
     experiment: str = "sample"
     per_device_eval_batch_size: int = 2
     per_device_train_batch_size: int = 2
-    metadata_list: List[str] = field(default_factory=list)
-    metadata_sep: str = " | "
-    metadata_key_value_sep: str = ": "
-    global_metadata_sep: str = " |||"
-    max_seq_len: int = 512
+    metadata_list: List[str] = field(default_factory=list)  # A sorted list of all kinds of metadata to be used
+    metadata_sep: str = (
+        " | "  # The separator to be used between different kinds of global metadata (e.g., timestamp and URL)
+    )
+    metadata_key_value_sep: str = ": "  # The default separator used between a metadata key and its associated value
+    metadata_probability: float = 1  # The probability of adding metadata to an input example
+    global_metadata_sep: str = " |||"  # The separator to be used between global metadata and the actual input text
+    max_seq_len: int = 512  # The maximum sequence length to be used for training
     dataset_name: Optional[str] = None  # The name of the dataset to use (via the datasets library)
     dataset_config_name: Optional[
         str

--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,13 @@ def req_file(filename):
 
 install_requires = req_file("requirements.txt")
 
-# TODO Fill
 setup(
-    name="MyPackageName",
+    name="bsmetadata",
     version="0.0.0",
     url="https://github.com/bigscience-workshop/metadata.git",
-    author="Author Name",
-    author_email="author@gmail.com",
-    description="Description of my package",
+    author="Multiple Authors",
+    author_email="xxx",
+    description="Codebase for including metadata (e.g., URLs, timestamps, HTML tags) during language model pretraining.",
     packages=find_packages(),
     install_requires=install_requires,
 )

--- a/tests/test_metadata_utils.py
+++ b/tests/test_metadata_utils.py
@@ -105,10 +105,30 @@ class MetadataUtilsTester(unittest.TestCase):
             "000111111111111111111111111111111111100000111111111111111111111111111111111111000000000000000000000000000000000001111111111111111110000011111111110000011111111110000000000000000000",
         )
 
+    def test_add_no_metadata_and_chunk_examples(self):
+        cfg = DataConfig()
+        cfg.metadata_list = ["url", "timestamp", "html", "entity"]
+        cfg.max_seq_len = 64
+        cfg.metadata_probability = 0
+
+        ds_dict = {key: [self.examples[0][key], self.examples[1][key]] for key in self.examples[0].keys()}
+        ds = Dataset.from_dict(ds_dict)
+
+        mapped_ds = ds.map(
+            functools.partial(add_metadata_and_chunk_examples, tokenizer=self.tokenizer, cfg=cfg),
+            batched=True,
+            remove_columns=ds.column_names,
+            load_from_cache_file=False,
+        )
+
+        for example in mapped_ds:
+            self.assertTrue(all(not x for x in example["metadata_mask"]))
+
     def test_add_metadata_and_chunk_examples(self):
         cfg = DataConfig()
         cfg.metadata_list = ["url", "timestamp", "html", "entity"]
         cfg.max_seq_len = 64
+        cfg.metadata_probability = 1
 
         PROCESSORS["timestamp"] = MetadataProcessor
 


### PR DESCRIPTION
This PR adds a parameter `metadata_probability` to the `DataConfig`, which controls the probability of adding metadata to an input example.
Right now, whether to add metadata is decided once for each input (as opposed to making individual decisions for each chunk) - we might want to change this later.  