### PR TITLE
Randomly include metadata with a given probability

### DIFF
--- a/bsmetadata/input_pipeline.py
+++ b/bsmetadata/input_pipeline.py
@@ -7,11 +7,14 @@ class DataConfig:
     experiment: str = "sample"
     per_device_eval_batch_size: int = 2
     per_device_train_batch_size: int = 2
-    metadata_list: List[str] = field(default_factory=list)
-    metadata_sep: str = " | "
-    metadata_key_value_sep: str = ": "
-    global_metadata_sep: str = " |||"
-    max_seq_len: int = 512
+    metadata_list: List[str] = field(default_factory=list)  # A sorted list of all kinds of metadata to be used
+    metadata_sep: str = (
+        " | "  # The separator to be used between different kinds of global metadata (e.g., timestamp and URL)
+    )
+    metadata_key_value_sep: str = ": "  # The default separator used between a metadata key and its associated value
+    metadata_probability: float = 1  # The probability of adding metadata to an input example
+    global_metadata_sep: str = " |||"  # The separator to be used between global metadata and the actual input text
+    max_seq_len: int = 512  # The maximum sequence length to be used for training
     dataset_name: Optional[str] = None  # The name of the dataset to use (via the datasets library)
     dataset_config_name: Optional[
         str

--- a/tests/test_metadata_utils.py
+++ b/tests/test_metadata_utils.py
@@ -105,10 +105,30 @@ class MetadataUtilsTester(unittest.TestCase):
             "000111111111111111111111111111111111100000111111111111111111111111111111111111000000000000000000000000000000000001111111111111111110000011111111110000011111111110000000000000000000",
         )
 
+    def test_add_no_metadata_and_chunk_examples(self):
+        cfg = DataConfig()
+        cfg.metadata_list = ["url", "timestamp", "html", "entity"]
+        cfg.max_seq_len = 64
+        cfg.metadata_probability = 0
+
+        ds_dict = {key: [self.examples[0][key], self.examples[1][key]] for key in self.examples[0].keys()}
+        ds = Dataset.from_dict(ds_dict)
+
+        mapped_ds = ds.map(
+            functools.partial(add_metadata_and_chunk_examples, tokenizer=self.tokenizer, cfg=cfg),
+            batched=True,
+            remove_columns=ds.column_names,
+            load_from_cache_file=False,
+        )
+
+        for example in mapped_ds:
+            self.assertTrue(all(not x for x in example["metadata_mask"]))
+
     def test_add_metadata_and_chunk_examples(self):
         cfg = DataConfig()
         cfg.metadata_list = ["url", "timestamp", "html", "entity"]
         cfg.max_seq_len = 64
+        cfg.metadata_probability = 1
 
         PROCESSORS["timestamp"] = MetadataProcessor
 


### PR DESCRIPTION
This PR adds a parameter `metadata_probability` to the `DataConfig`, which controls the probability of adding metadata to an input example.
Right now, whether to add metadata is decided once for each input (as opposed to making individual decisions for each chunk) - we might want to change this later.