### PR TITLE
Remove global metadata separator when there is only local metadata

### DIFF
--- a/bsmetadata/metadata_utils.py
+++ b/bsmetadata/metadata_utils.py
@@ -63,7 +63,8 @@ def add_metadata_and_chunk_examples(
             text_with_local_metadata = example["text"]
             char_level_metadata_mask = [False] * len(text_with_local_metadata)
 
-        text_with_local_metadata = " " + text_with_local_metadata
+        if global_metadata_prefix_encoded:
+            text_with_local_metadata = " " + text_with_local_metadata
         char_level_metadata_mask = [False] + char_level_metadata_mask
         text_with_local_metadata_encoded = tokenizer.encode_plus(text_with_local_metadata)
 
@@ -118,7 +119,7 @@ def create_global_metadata_prefix(example: Dict[str, Any], cfg: DataConfig) -> s
 
     sorted_metadata = [processed_metadata.get(md, None) for md in cfg.metadata_list]
     sorted_metadata = [md for md in sorted_metadata if md is not None]
-    return cfg.metadata_sep.join(sorted_metadata) + cfg.global_metadata_sep
+    return cfg.metadata_sep.join(sorted_metadata) + cfg.global_metadata_sep if sorted_metadata else ""
 
 
 def add_local_metadata_to_text(example: Dict[str, Any], cfg: DataConfig) -> Tuple[str, List[bool]]:

--- a/tests/test_get_dataloaders.py
+++ b/tests/test_get_dataloaders.py
@@ -18,16 +18,51 @@ logger = logging.getLogger()
 @pytest.mark.parametrize(
     "metadata_list",
     [
+        ["html"],
+        ["entity"],
+    ],
+)
+def test_get_dataloaders_with_metadata(metadata_list):
+    path = Path(__file__)
+    path_test_folder = path.parent.absolute()
+
+    data_config = DataConfig(
+        train_file=os.path.join(path_test_folder, "data", "train_toy_wikitext_with_metadata.jsonl"),
+        validation_file=os.path.join(path_test_folder, "data", "val_toy_wikitext_with_metadata.jsonl"),
+        metadata_list=metadata_list,
+        max_seq_len=100,
+    )
+
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    train_dataloader, eval_dataloaders = get_dataloaders_with_metadata(tokenizer=tokenizer, args=data_config)
+
+    batch = next(iter(train_dataloader))
+
+    # Check if the right keys are in the train batch
+    assert "attention_mask" in batch.keys()
+    assert "input_ids" in batch.keys()
+    assert "metadata_mask" in batch.keys()
+
+    batch_val = next(iter(list(eval_dataloaders.values())[0]))
+
+    # Check if the right keys are in the train batch
+    assert "attention_mask" in batch_val.keys()
+    assert "input_ids" in batch_val.keys()
+    assert "metadata_mask" in batch_val.keys()
+
+
+@pytest.mark.parametrize(
+    "metadata_list",
+    [
         ["url"],
         ["timestamp"],
-        ["entity"],
         ["url", "timestamp"],
         ["url", "entity"],
         ["timestamp", "entity"],
         ["url", "timestamp", "entity"],
     ],
 )
-def test_get_dataloaders_with_metadata(metadata_list):
+def test_get_dataloaders_with_metadata_start_with_metadata_mask(metadata_list):
     path = Path(__file__)
     path_test_folder = path.parent.absolute()
 


### PR DESCRIPTION
Fix #22 

In this PR, I propose to remove the `global_metadata_sep` when not adding global metadata but only local ones.

I changed the test accordingly :slightly_smiling_face: 