### PR TITLE
Fix metadata mask for local only metadata

### DIFF
--- a/bsmetadata/metadata_utils.py
+++ b/bsmetadata/metadata_utils.py
@@ -64,7 +64,8 @@ def add_metadata_and_chunk_examples(
 
         if global_metadata_prefix_encoded:
             text_with_local_metadata = " " + text_with_local_metadata
-        char_level_metadata_mask = [False] + char_level_metadata_mask
+            char_level_metadata_mask = [False] + char_level_metadata_mask
+        
         text_with_local_metadata_encoded = tokenizer.encode_plus(text_with_local_metadata)
 
         def is_metadata(idx: int) -> bool:

--- a/bsmetadata/metadata_utils.py
+++ b/bsmetadata/metadata_utils.py
@@ -65,7 +65,7 @@ def add_metadata_and_chunk_examples(
         if global_metadata_prefix_encoded:
             text_with_local_metadata = " " + text_with_local_metadata
             char_level_metadata_mask = [False] + char_level_metadata_mask
-        
+
         text_with_local_metadata_encoded = tokenizer.encode_plus(text_with_local_metadata)
 
         def is_metadata(idx: int) -> bool:


### PR DESCRIPTION
# What this PR do?

When adding only global metadata (without global metadata at the beginning see #23), there was an offset of 1 on the metadata mask. This PR proposes to resolve this offset.