### PR TITLE
feat: add argument to treat local metadata as regular text or not

### DIFF
--- a/bsmetadata/metadata_processors.py
+++ b/bsmetadata/metadata_processors.py
@@ -36,9 +36,23 @@ class MetadataConfig:
     metadata_probability: float = field(
         default=1, metadata={"help": "The probability of adding metadata to an input example."}
     )
+    add_special_token_for_metadata_generation: bool = field(
+        default=True,
+        metadata={
+            "help": "If True, some special tokens are added at the begining of the sample to indicate the type of "
+            "metadata added in the sample. The special tokens used are equal to the string used in `metadata_list`"
+        },
+    )
     global_metadata_sep: str = field(
         default=" |||",
         metadata={"help": "The character sequence that is used to separate all global metadata from the actual text."},
+    )
+    special_token_for_metadata_generation_sep: str = field(
+        default=" |||",
+        metadata={
+            "help": "The character sequence that is used to separate the special tokens controlling the generation of "
+            "metadata from (eventually) the global metadata and the actual text."
+        },
     )
     max_seq_len: int = field(
         default=512, metadata={"help": "The maximum number of tokens to use for each training chunk."}

--- a/bsmetadata/metadata_processors.py
+++ b/bsmetadata/metadata_processors.py
@@ -37,7 +37,7 @@ class MetadataConfig:
         default=1, metadata={"help": "The probability of adding metadata to an input example."}
     )
     add_special_token_for_metadata_generation: bool = field(
-        default=True,
+        default=False,
         metadata={
             "help": "If True, some special tokens are added at the begining of the sample to indicate the type of "
             "metadata added in the sample. The special tokens used are equal to the string used in `metadata_list`"

--- a/bsmetadata/metadata_processors.py
+++ b/bsmetadata/metadata_processors.py
@@ -70,6 +70,13 @@ class MetadataConfig:
             "help": "The character sequence to be concatenated at the beginning of character sequence of special tokens for metadata generation."
         },
     )
+    treat_local_metadata_as_regular_text: bool = field(
+        default=False,
+        metadata={
+            "help": "If True, local metadata token will be associated to a `0` int the metadata_mask list. If False, "
+            "local metadata token will be associated to a `1` int the metadata_mask list"
+        },
+    )
     max_seq_len: int = field(
         default=512, metadata={"help": "The maximum number of tokens to use for each training chunk."}
     )

--- a/bsmetadata/metadata_processors.py
+++ b/bsmetadata/metadata_processors.py
@@ -29,6 +29,10 @@ class MetadataConfig:
         default=" | ",
         metadata={"help": "The character sequence that is used to separate two instances of global metadata."},
     )
+    special_tokens_metadata_sep: str = field(
+        default=" ",
+        metadata={"help": "The character sequence that is used to separate two instances of special token metadata."},
+    )
     metadata_key_value_sep: str = field(
         default=": ",
         metadata={"help": "The character sequence that is used by default to separate a metadata key and its value."},
@@ -36,22 +40,34 @@ class MetadataConfig:
     metadata_probability: float = field(
         default=1, metadata={"help": "The probability of adding metadata to an input example."}
     )
-    add_special_token_for_metadata_generation: bool = field(
+    metadata_add_special_token_for_generation: bool = field(
         default=False,
         metadata={
             "help": "If True, some special tokens are added at the begining of the sample to indicate the type of "
             "metadata added in the sample. The special tokens used are equal to the string used in `metadata_list`"
         },
     )
-    global_metadata_sep: str = field(
+    metadata_global_sep: str = field(
         default=" |||",
         metadata={"help": "The character sequence that is used to separate all global metadata from the actual text."},
     )
-    special_token_for_metadata_generation_sep: str = field(
+    metadata_global_start_seq: str = field(
+        default="",
+        metadata={
+            "help": "The character sequence to be concatenated at the beginning of the global metadata-specific character sequence."
+        },
+    )
+    metadata_special_token_for_generation_sep: str = field(
         default=" |||",
         metadata={
             "help": "The character sequence that is used to separate the special tokens controlling the generation of "
             "metadata from (eventually) the global metadata and the actual text."
+        },
+    )
+    metadata_special_token_for_generation_start_seq: str = field(
+        default="",
+        metadata={
+            "help": "The character sequence to be concatenated at the beginning of character sequence of special tokens for metadata generation."
         },
     )
     max_seq_len: int = field(

--- a/bsmetadata/metadata_utils.py
+++ b/bsmetadata/metadata_utils.py
@@ -120,9 +120,12 @@ def add_metadata_and_chunk_examples(
             char_range = range(char_span.start, char_span.end)
             return any(char_level_metadata_mask[c] for c in char_range)
 
-        token_level_metadata_mask = [
-            is_metadata(idx) for idx, _ in enumerate(text_with_local_metadata_encoded.input_ids)
-        ]
+        if cfg.treat_local_metadata_as_regular_text:
+            token_level_metadata_mask = [0] * len(text_with_local_metadata_encoded.input_ids)
+        else:
+            token_level_metadata_mask = [
+                is_metadata(idx) for idx, _ in enumerate(text_with_local_metadata_encoded.input_ids)
+            ]
 
         # Create chunks of `max_seq_len` tokens.
         prefix_special_tokens_encoded = (

--- a/bsmetadata/metadata_utils.py
+++ b/bsmetadata/metadata_utils.py
@@ -157,14 +157,16 @@ def add_metadata_and_chunk_examples(
 
 
 def create_global_metadata_prefix(example: Dict[str, Any], cfg: MetadataConfig) -> str:
-    """Creates a prefix containing all global metadata information (including URLs, timestamps, etc). TODO complete
+    """Creates a prefix containing all global metadata information (including URLs, timestamps, etc).
 
     Args:
         example: The example to create a global metadata prefix for.
         cfg: The data config to use.
 
     Returns:
-        A string containing the global metadata prefix.
+        A tuple of two elements, where:
+            - the first element a string containing the global metadata prefix;
+            - the second element is a string contening the name of the metadata types added.
     """
     processed_metadata = {}
     for metadata in example["metadata"]:
@@ -255,9 +257,10 @@ def add_local_metadata_to_text(example: Dict[str, Any], cfg: MetadataConfig) -> 
         cfg: The data config to use.
 
     Returns:
-        A tuple of two elements, where:
+        A tuple of three elements, where:
             - the first element is the text with metadata;
-            - the second element is a boolean mask where `mask[i]` is set iff `text[i]` is some kind of metadata.
+            - the second element is a boolean mask where `mask[i]` is set iff `text[i]` is some kind of metadata;
+            - the third element is a string listing the types of metadata added
     """
     metadata_idx_storage = MetadataIdxStorage()
 

--- a/tests/test_metadata_utils.py
+++ b/tests/test_metadata_utils.py
@@ -267,24 +267,51 @@ class MetadataUtilsTester(unittest.TestCase):
         cfg = MetadataConfig()
         cfg.metadata_key_value_sep = ": "
         cfg.metadata_sep = " | "
-        cfg.global_metadata_sep = " |||"
+        cfg.metadata_global_sep = " |||"
         cfg.metadata_list = ["url", "timestamp", "website_description"]
         PROCESSORS["timestamp"] = MetadataProcessor
 
+        global_metadata_prefix_1, global_metadata_special_tokens_prefix_1 = create_global_metadata_prefix(
+            self.examples[0], cfg
+        )
+        global_metadata_prefix_2, global_metadata_special_tokens_prefix_2 = create_global_metadata_prefix(
+            self.examples[1], cfg
+        )
+        global_metadata_prefix_3, global_metadata_special_tokens_prefix_3 = create_global_metadata_prefix(
+            self.examples[2], cfg
+        )
+        global_metadata_prefix_4, global_metadata_special_tokens_prefix_4 = create_global_metadata_prefix(
+            self.examples[3], cfg
+        )
+
         self.assertEqual(
-            create_global_metadata_prefix(self.examples[0], cfg),
-            "url: https://www.bbc.com/sport/live/olympics/50974152 | timestamp: 2018-12-10T13:45:00.000Z |||",
+            global_metadata_prefix_1,
+            "url: https://www.bbc.com/sport/live/olympics/50974152 | timestamp: 2018-12-10T13:45:00.000Z",
         )
         self.assertEqual(
-            create_global_metadata_prefix(self.examples[1], cfg), "url: https://en.wikipedia.org/wiki/Apple |||"
+            global_metadata_special_tokens_prefix_1,
+            "url timestamp",
+        )
+
+        self.assertEqual(global_metadata_prefix_2, "url: https://en.wikipedia.org/wiki/Apple")
+        self.assertEqual(
+            global_metadata_special_tokens_prefix_2,
+            "url",
+        )
+
+        self.assertEqual(global_metadata_prefix_3, "url: callto:RickAndMorty/Year 2021/")
+        self.assertEqual(
+            global_metadata_special_tokens_prefix_3,
+            "url",
+        )
+
+        self.assertEqual(
+            global_metadata_prefix_4,
+            "Website Description: Amazon.com, Inc. ( AM-ə-zon) is an American multinational conglomerate which focuses on e-commerce, cloud computing, digital streaming, and artificial intelligence.",
         )
         self.assertEqual(
-            create_global_metadata_prefix(self.examples[2], cfg), "url: callto:RickAndMorty/Year 2021/ |||"
-        )
-        cfg.metadata_list = ["website_description"]
-        self.assertEqual(
-            create_global_metadata_prefix(self.examples[3], cfg),
-            "Website Description: Amazon.com, Inc. ( AM-ə-zon) is an American multinational conglomerate which focuses on e-commerce, cloud computing, digital streaming, and artificial intelligence. |||",
+            global_metadata_special_tokens_prefix_4,
+            "website_description",
         )
 
     def test_add_local_metadata_to_text(self):
@@ -292,8 +319,8 @@ class MetadataUtilsTester(unittest.TestCase):
         cfg.metadata_list = ["html", "entity"]
         PROCESSORS["html"] = MetadataProcessor
         PROCESSORS["entity"] = MetadataProcessor
-        text1, mask1 = add_local_metadata_to_text(self.examples[0], cfg)
-        text2, mask2 = add_local_metadata_to_text(self.examples[1], cfg)
+        text1, mask1, local_metadata_special_tokens_prefix1 = add_local_metadata_to_text(self.examples[0], cfg)
+        text2, mask2, local_metadata_special_tokens_prefix2 = add_local_metadata_to_text(self.examples[1], cfg)
 
         self.assertEqual(
             text1,
@@ -303,6 +330,10 @@ class MetadataUtilsTester(unittest.TestCase):
             "".join(str(int(x)) for x in mask1),
             "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001111111111111111111110000011111111111111111111110000000000000000000",
         )
+        self.assertEqual(
+            local_metadata_special_tokens_prefix1,
+            "entity",
+        )
 
         self.assertEqual(
             text2,
@@ -311,6 +342,10 @@ class MetadataUtilsTester(unittest.TestCase):
         self.assertEqual(
             "".join(str(int(x)) for x in mask2),
             "000111111111111111111111111111111111100000111111111111111111111111111111111111000000000000000000000000000000000001111111111111111110000011111111110000011111111110000000000000000000",
+        )
+        self.assertEqual(
+            local_metadata_special_tokens_prefix2,
+            "html entity",
         )
 
     def test_add_no_metadata_and_chunk_examples(self):
@@ -1640,6 +1675,102 @@ class MetadataUtilsTester(unittest.TestCase):
             self.tokenizer.decode(mapped_ds[2]["input_ids"]),
             "url: https://en.wikipedia.org/wiki/Apple ||| An <b>apple [[Malus domestica]]</b> is an edible fruit produced by an <a></a><b class:level1><b class:level2><i class:level3><a></a>apple</i> tree</b></b> (Malus domestica).<|endoftext|>",
         )
+
+    def test_add_metadata_and_chunk_examples_with_true_processor_and_metadata_special_tokens(self):
+        cfg = MetadataConfig()
+        cfg.metadata_list = ["url", "timestamp", "html", "entity"]
+        cfg.max_seq_len = 85
+        cfg.metadata_probability = 1
+        cfg.metadata_add_special_token_for_generation = True
+        cfg.metadata_special_token_for_generation_start_seq = " "
+        cfg.metadata_global_start_seq = " "
+
+        PROCESSORS["url"] = UrlProcessor
+        PROCESSORS["timestamp"] = TimestampProcessor
+        PROCESSORS["html"] = HtmlProcessor
+        PROCESSORS["entity"] = EntityProcessor
+
+        ds_dict = {
+            key: [self.examples[1][key], self.examples[4][key], self.examples[4][key]]
+            for key in self.examples[0].keys()
+        }
+        ds = Dataset.from_dict(ds_dict)
+
+        mapped_ds = ds.map(
+            functools.partial(add_metadata_and_chunk_examples, tokenizer=self.tokenizer, cfg=cfg),
+            batched=True,
+            remove_columns=ds.column_names,
+            load_from_cache_file=False,
+        )
+
+        self.maxDiff = None
+
+        self.assertEqual(
+            self.tokenizer.decode(mapped_ds[0]["input_ids"]),
+            " url html entity ||| url: https://en.wikipedia.org/wiki/Apple ||| An <b>apple [[Malus domestica]]</b> is an edible fruit produced by an <b class:level1><i class:level2>apple</i> tree</b> (Malus domestica).<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>",
+        )
+        self.assertEqual(
+            self.tokenizer.decode(mapped_ds[1]["input_ids"]),
+            " url html entity ||| url: https://en.wikipedia.org/wiki/Apple ||| An <b>apple [[Malus domestica]]</b> is an edible fruit produced by an <a></a><b class:level1><b class:level2><i class:level3><a></a>apple</i> tree</b></b> (Malus domestica).<|endoftext|>",
+        )
+        self.assertEqual(
+            self.tokenizer.decode(mapped_ds[2]["input_ids"]),
+            " url html entity ||| url: https://en.wikipedia.org/wiki/Apple ||| An <b>apple [[Malus domestica]]</b> is an edible fruit produced by an <a></a><b class:level1><b class:level2><i class:level3><a></a>apple</i> tree</b></b> (Malus domestica).<|endoftext|>",
+        )
+
+        # fmt: off
+        self.assertEqual(self.tokenizer.convert_ids_to_tokens(mapped_ds[0]["input_ids"]), ['Ġurl', 'Ġhtml', 'Ġentity', 'Ġ||', '|', 'Ġurl', ':', 'Ġhttps', '://', 'en', '.', 'wikipedia', '.', 'org', '/', 'wiki', '/', 'Apple', 'Ġ||', '|', 'ĠAn', 'Ġ<', 'b', '>', 'apple', 'Ġ[[', 'Mal', 'us', 'Ġdomest', 'ica', ']]', '</', 'b', '>', 'Ġis', 'Ġan', 'Ġedible', 'Ġfruit', 'Ġproduced', 'Ġby', 'Ġan', 'Ġ<', 'b', 'Ġclass', ':', 'level', '1', '><', 'i', 'Ġclass', ':', 'level', '2', '>', 'apple', '</', 'i', '>', 'Ġtree', '</', 'b', '>', 'Ġ(', 'Mal', 'us', 'Ġdomest', 'ica', ').', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>'])
+        self.assertEqual(self.tokenizer.convert_ids_to_tokens(mapped_ds[1]["input_ids"]), ['Ġurl', 'Ġhtml', 'Ġentity', 'Ġ||', '|', 'Ġurl', ':', 'Ġhttps', '://', 'en', '.', 'wikipedia', '.', 'org', '/', 'wiki', '/', 'Apple', 'Ġ||', '|', 'ĠAn', 'Ġ<', 'b', '>', 'apple', 'Ġ[[', 'Mal', 'us', 'Ġdomest', 'ica', ']]', '</', 'b', '>', 'Ġis', 'Ġan', 'Ġedible', 'Ġfruit', 'Ġproduced', 'Ġby', 'Ġan', 'Ġ<', 'a', '></', 'a', '><', 'b', 'Ġclass', ':', 'level', '1', '><', 'b', 'Ġclass', ':', 'level', '2', '><', 'i', 'Ġclass', ':', 'level', '3', '><', 'a', '></', 'a', '>', 'apple', '</', 'i', '>', 'Ġtree', '</', 'b', '></', 'b', '>', 'Ġ(', 'Mal', 'us', 'Ġdomest', 'ica', ').', '<|endoftext|>'])
+        self.assertEqual(self.tokenizer.convert_ids_to_tokens(mapped_ds[2]["input_ids"]), ['Ġurl', 'Ġhtml', 'Ġentity', 'Ġ||', '|', 'Ġurl', ':', 'Ġhttps', '://', 'en', '.', 'wikipedia', '.', 'org', '/', 'wiki', '/', 'Apple', 'Ġ||', '|', 'ĠAn', 'Ġ<', 'b', '>', 'apple', 'Ġ[[', 'Mal', 'us', 'Ġdomest', 'ica', ']]', '</', 'b', '>', 'Ġis', 'Ġan', 'Ġedible', 'Ġfruit', 'Ġproduced', 'Ġby', 'Ġan', 'Ġ<', 'a', '></', 'a', '><', 'b', 'Ġclass', ':', 'level', '1', '><', 'b', 'Ġclass', ':', 'level', '2', '><', 'i', 'Ġclass', ':', 'level', '3', '><', 'a', '></', 'a', '>', 'apple', '</', 'i', '>', 'Ġtree', '</', 'b', '></', 'b', '>', 'Ġ(', 'Mal', 'us', 'Ġdomest', 'ica', ').', '<|endoftext|>'])
+        # fmt: on
+
+    def test_add_metadata_and_chunk_examples_with_true_processor_and_metadata_special_tokens_without_global(self):
+        cfg = MetadataConfig()
+        cfg.metadata_list = ["html", "entity"]
+        cfg.max_seq_len = 68
+        cfg.metadata_probability = 1
+        cfg.metadata_add_special_token_for_generation = True
+        cfg.metadata_special_token_for_generation_start_seq = " "
+        cfg.metadata_global_start_seq = " "
+
+        PROCESSORS["url"] = UrlProcessor
+        PROCESSORS["timestamp"] = TimestampProcessor
+        PROCESSORS["html"] = HtmlProcessor
+        PROCESSORS["entity"] = EntityProcessor
+
+        ds_dict = {
+            key: [self.examples[1][key], self.examples[4][key], self.examples[4][key]]
+            for key in self.examples[0].keys()
+        }
+        ds = Dataset.from_dict(ds_dict)
+
+        mapped_ds = ds.map(
+            functools.partial(add_metadata_and_chunk_examples, tokenizer=self.tokenizer, cfg=cfg),
+            batched=True,
+            remove_columns=ds.column_names,
+            load_from_cache_file=False,
+        )
+
+        self.maxDiff = None
+
+        self.assertEqual(
+            self.tokenizer.decode(mapped_ds[0]["input_ids"]),
+            " html entity ||| An <b>apple [[Malus domestica]]</b> is an edible fruit produced by an <b class:level1><i class:level2>apple</i> tree</b> (Malus domestica).<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>",
+        )
+        self.assertEqual(
+            self.tokenizer.decode(mapped_ds[1]["input_ids"]),
+            " html entity ||| An <b>apple [[Malus domestica]]</b> is an edible fruit produced by an <a></a><b class:level1><b class:level2><i class:level3><a></a>apple</i> tree</b></b> (Malus domestica).",
+        )
+        self.assertEqual(
+            self.tokenizer.decode(mapped_ds[2]["input_ids"]),
+            " html entity ||| An <b>apple [[Malus domestica]]</b> is an edible fruit produced by an <a></a><b class:level1><b class:level2><i class:level3><a></a>apple</i> tree</b></b> (Malus domestica).",
+        )
+
+        # fmt: off
+        self.assertEqual(self.tokenizer.convert_ids_to_tokens(mapped_ds[0]["input_ids"]), ['Ġhtml', 'Ġentity', 'Ġ||', '|', 'ĠAn', 'Ġ<', 'b', '>', 'apple', 'Ġ[[', 'Mal', 'us', 'Ġdomest', 'ica', ']]', '</', 'b', '>', 'Ġis', 'Ġan', 'Ġedible', 'Ġfruit', 'Ġproduced', 'Ġby', 'Ġan', 'Ġ<', 'b', 'Ġclass', ':', 'level', '1', '><', 'i', 'Ġclass', ':', 'level', '2', '>', 'apple', '</', 'i', '>', 'Ġtree', '</', 'b', '>', 'Ġ(', 'Mal', 'us', 'Ġdomest', 'ica', ').', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>'],)
+        self.assertEqual(self.tokenizer.convert_ids_to_tokens(mapped_ds[1]["input_ids"]), ['Ġhtml', 'Ġentity', 'Ġ||', '|', 'ĠAn', 'Ġ<', 'b', '>', 'apple', 'Ġ[[', 'Mal', 'us', 'Ġdomest', 'ica', ']]', '</', 'b', '>', 'Ġis', 'Ġan', 'Ġedible', 'Ġfruit', 'Ġproduced', 'Ġby', 'Ġan', 'Ġ<', 'a', '></', 'a', '><', 'b', 'Ġclass', ':', 'level', '1', '><', 'b', 'Ġclass', ':', 'level', '2', '><', 'i', 'Ġclass', ':', 'level', '3', '><', 'a', '></', 'a', '>', 'apple', '</', 'i', '>', 'Ġtree', '</', 'b', '></', 'b', '>', 'Ġ(', 'Mal', 'us', 'Ġdomest', 'ica', ').'],)
+        self.assertEqual(self.tokenizer.convert_ids_to_tokens(mapped_ds[2]["input_ids"]), ['Ġhtml', 'Ġentity', 'Ġ||', '|', 'ĠAn', 'Ġ<', 'b', '>', 'apple', 'Ġ[[', 'Mal', 'us', 'Ġdomest', 'ica', ']]', '</', 'b', '>', 'Ġis', 'Ġan', 'Ġedible', 'Ġfruit', 'Ġproduced', 'Ġby', 'Ġan', 'Ġ<', 'a', '></', 'a', '><', 'b', 'Ġclass', ':', 'level', '1', '><', 'b', 'Ġclass', ':', 'level', '2', '><', 'i', 'Ġclass', ':', 'level', '3', '><', 'a', '></', 'a', '>', 'apple', '</', 'i', '>', 'Ġtree', '</', 'b', '></', 'b', '>', 'Ġ(', 'Mal', 'us', 'Ġdomest', 'ica', ').'],)
+        # fmt: on
 
 
 if __name__ == "__main__":

--- a/tests/test_metadata_utils.py
+++ b/tests/test_metadata_utils.py
@@ -319,8 +319,8 @@ class MetadataUtilsTester(unittest.TestCase):
         cfg.metadata_list = ["html", "entity"]
         PROCESSORS["html"] = MetadataProcessor
         PROCESSORS["entity"] = MetadataProcessor
-        text1, mask1, local_metadata_special_tokens_prefix1 = add_local_metadata_to_text(self.examples[0], cfg)
-        text2, mask2, local_metadata_special_tokens_prefix2 = add_local_metadata_to_text(self.examples[1], cfg)
+        text1, mask1, local_metadata_special_tokens_prefix_1 = add_local_metadata_to_text(self.examples[0], cfg)
+        text2, mask2, local_metadata_special_tokens_prefix_2 = add_local_metadata_to_text(self.examples[1], cfg)
 
         self.assertEqual(
             text1,
@@ -331,7 +331,7 @@ class MetadataUtilsTester(unittest.TestCase):
             "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001111111111111111111110000011111111111111111111110000000000000000000",
         )
         self.assertEqual(
-            local_metadata_special_tokens_prefix1,
+            local_metadata_special_tokens_prefix_1,
             "entity",
         )
 
@@ -344,7 +344,7 @@ class MetadataUtilsTester(unittest.TestCase):
             "000111111111111111111111111111111111100000111111111111111111111111111111111111000000000000000000000000000000000001111111111111111110000011111111110000011111111110000000000000000000",
         )
         self.assertEqual(
-            local_metadata_special_tokens_prefix2,
+            local_metadata_special_tokens_prefix_2,
             "html entity",
         )
 
@@ -354,7 +354,10 @@ class MetadataUtilsTester(unittest.TestCase):
         cfg.max_seq_len = 64
         cfg.metadata_probability = 0
 
-        ds_dict = {key: [self.examples[0][key], self.examples[1][key]] for key in self.examples[0].keys()}
+        ds_dict = {
+            key: [self.examples[0][key], self.examples[1][key], self.examples[2][key], self.examples[3][key]]
+            for key in self.examples[0].keys()
+        }
         ds = Dataset.from_dict(ds_dict)
 
         mapped_ds = ds.map(
@@ -378,7 +381,7 @@ class MetadataUtilsTester(unittest.TestCase):
             key: [self.examples[0][key], self.examples[1][key], self.examples[3][key]]
             for key in self.examples[0].keys()
         }
-        print(ds_dict)
+
         ds = Dataset.from_dict(ds_dict)
 
         mapped_ds = ds.map(

--- a/tests/test_metadata_utils.py
+++ b/tests/test_metadata_utils.py
@@ -1773,6 +1773,119 @@ class MetadataUtilsTester(unittest.TestCase):
         self.assertEqual(self.tokenizer.convert_ids_to_tokens(mapped_ds[0]["input_ids"]), ['Ġhtml', 'Ġentity', 'Ġ||', '|', 'ĠAn', 'Ġ<', 'b', '>', 'apple', 'Ġ[[', 'Mal', 'us', 'Ġdomest', 'ica', ']]', '</', 'b', '>', 'Ġis', 'Ġan', 'Ġedible', 'Ġfruit', 'Ġproduced', 'Ġby', 'Ġan', 'Ġ<', 'b', 'Ġclass', ':', 'level', '1', '><', 'i', 'Ġclass', ':', 'level', '2', '>', 'apple', '</', 'i', '>', 'Ġtree', '</', 'b', '>', 'Ġ(', 'Mal', 'us', 'Ġdomest', 'ica', ').', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>'],)
         self.assertEqual(self.tokenizer.convert_ids_to_tokens(mapped_ds[1]["input_ids"]), ['Ġhtml', 'Ġentity', 'Ġ||', '|', 'ĠAn', 'Ġ<', 'b', '>', 'apple', 'Ġ[[', 'Mal', 'us', 'Ġdomest', 'ica', ']]', '</', 'b', '>', 'Ġis', 'Ġan', 'Ġedible', 'Ġfruit', 'Ġproduced', 'Ġby', 'Ġan', 'Ġ<', 'a', '></', 'a', '><', 'b', 'Ġclass', ':', 'level', '1', '><', 'b', 'Ġclass', ':', 'level', '2', '><', 'i', 'Ġclass', ':', 'level', '3', '><', 'a', '></', 'a', '>', 'apple', '</', 'i', '>', 'Ġtree', '</', 'b', '></', 'b', '>', 'Ġ(', 'Mal', 'us', 'Ġdomest', 'ica', ').'],)
         self.assertEqual(self.tokenizer.convert_ids_to_tokens(mapped_ds[2]["input_ids"]), ['Ġhtml', 'Ġentity', 'Ġ||', '|', 'ĠAn', 'Ġ<', 'b', '>', 'apple', 'Ġ[[', 'Mal', 'us', 'Ġdomest', 'ica', ']]', '</', 'b', '>', 'Ġis', 'Ġan', 'Ġedible', 'Ġfruit', 'Ġproduced', 'Ġby', 'Ġan', 'Ġ<', 'a', '></', 'a', '><', 'b', 'Ġclass', ':', 'level', '1', '><', 'b', 'Ġclass', ':', 'level', '2', '><', 'i', 'Ġclass', ':', 'level', '3', '><', 'a', '></', 'a', '>', 'apple', '</', 'i', '>', 'Ġtree', '</', 'b', '></', 'b', '>', 'Ġ(', 'Mal', 'us', 'Ġdomest', 'ica', ').'],)
+
+        self.assertEqual(mapped_ds[0]["metadata_mask"], [1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        self.assertEqual(mapped_ds[1]["metadata_mask"], [1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0])
+        self.assertEqual(mapped_ds[2]["metadata_mask"], [1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0])
+        # fmt: on
+
+    def test_add_metadata_and_chunk_examples_treat_local_metadata_as_regular_text_without_global(self):
+        cfg = MetadataConfig()
+        cfg.metadata_list = ["html", "entity"]
+        cfg.max_seq_len = 68
+        cfg.metadata_probability = 1
+        cfg.metadata_add_special_token_for_generation = True
+        cfg.metadata_special_token_for_generation_start_seq = " "
+        cfg.metadata_global_start_seq = " "
+        cfg.treat_local_metadata_as_regular_text = True
+
+        PROCESSORS["url"] = UrlProcessor
+        PROCESSORS["timestamp"] = TimestampProcessor
+        PROCESSORS["html"] = HtmlProcessor
+        PROCESSORS["entity"] = EntityProcessor
+
+        ds_dict = {
+            key: [self.examples[1][key], self.examples[4][key], self.examples[4][key]]
+            for key in self.examples[0].keys()
+        }
+        ds = Dataset.from_dict(ds_dict)
+
+        mapped_ds = ds.map(
+            functools.partial(add_metadata_and_chunk_examples, tokenizer=self.tokenizer, cfg=cfg),
+            batched=True,
+            remove_columns=ds.column_names,
+            load_from_cache_file=False,
+        )
+
+        self.maxDiff = None
+
+        self.assertEqual(
+            self.tokenizer.decode(mapped_ds[0]["input_ids"]),
+            " html entity ||| An <b>apple [[Malus domestica]]</b> is an edible fruit produced by an <b class:level1><i class:level2>apple</i> tree</b> (Malus domestica).<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>",
+        )
+        self.assertEqual(
+            self.tokenizer.decode(mapped_ds[1]["input_ids"]),
+            " html entity ||| An <b>apple [[Malus domestica]]</b> is an edible fruit produced by an <a></a><b class:level1><b class:level2><i class:level3><a></a>apple</i> tree</b></b> (Malus domestica).",
+        )
+        self.assertEqual(
+            self.tokenizer.decode(mapped_ds[2]["input_ids"]),
+            " html entity ||| An <b>apple [[Malus domestica]]</b> is an edible fruit produced by an <a></a><b class:level1><b class:level2><i class:level3><a></a>apple</i> tree</b></b> (Malus domestica).",
+        )
+
+        # fmt: off
+        self.assertEqual(self.tokenizer.convert_ids_to_tokens(mapped_ds[0]["input_ids"]), ['Ġhtml', 'Ġentity', 'Ġ||', '|', 'ĠAn', 'Ġ<', 'b', '>', 'apple', 'Ġ[[', 'Mal', 'us', 'Ġdomest', 'ica', ']]', '</', 'b', '>', 'Ġis', 'Ġan', 'Ġedible', 'Ġfruit', 'Ġproduced', 'Ġby', 'Ġan', 'Ġ<', 'b', 'Ġclass', ':', 'level', '1', '><', 'i', 'Ġclass', ':', 'level', '2', '>', 'apple', '</', 'i', '>', 'Ġtree', '</', 'b', '>', 'Ġ(', 'Mal', 'us', 'Ġdomest', 'ica', ').', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>'],)
+        self.assertEqual(self.tokenizer.convert_ids_to_tokens(mapped_ds[1]["input_ids"]), ['Ġhtml', 'Ġentity', 'Ġ||', '|', 'ĠAn', 'Ġ<', 'b', '>', 'apple', 'Ġ[[', 'Mal', 'us', 'Ġdomest', 'ica', ']]', '</', 'b', '>', 'Ġis', 'Ġan', 'Ġedible', 'Ġfruit', 'Ġproduced', 'Ġby', 'Ġan', 'Ġ<', 'a', '></', 'a', '><', 'b', 'Ġclass', ':', 'level', '1', '><', 'b', 'Ġclass', ':', 'level', '2', '><', 'i', 'Ġclass', ':', 'level', '3', '><', 'a', '></', 'a', '>', 'apple', '</', 'i', '>', 'Ġtree', '</', 'b', '></', 'b', '>', 'Ġ(', 'Mal', 'us', 'Ġdomest', 'ica', ').'],)
+        self.assertEqual(self.tokenizer.convert_ids_to_tokens(mapped_ds[2]["input_ids"]), ['Ġhtml', 'Ġentity', 'Ġ||', '|', 'ĠAn', 'Ġ<', 'b', '>', 'apple', 'Ġ[[', 'Mal', 'us', 'Ġdomest', 'ica', ']]', '</', 'b', '>', 'Ġis', 'Ġan', 'Ġedible', 'Ġfruit', 'Ġproduced', 'Ġby', 'Ġan', 'Ġ<', 'a', '></', 'a', '><', 'b', 'Ġclass', ':', 'level', '1', '><', 'b', 'Ġclass', ':', 'level', '2', '><', 'i', 'Ġclass', ':', 'level', '3', '><', 'a', '></', 'a', '>', 'apple', '</', 'i', '>', 'Ġtree', '</', 'b', '></', 'b', '>', 'Ġ(', 'Mal', 'us', 'Ġdomest', 'ica', ').'],)
+
+        self.assertEqual(mapped_ds[0]["metadata_mask"], [1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] )
+        self.assertEqual(mapped_ds[1]["metadata_mask"], [1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] )
+        self.assertEqual(mapped_ds[2]["metadata_mask"], [1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] )
+        # fmt: on
+
+    def test_add_metadata_and_chunk_examples_treat_local_metadata_as_regular_text_with_global(self):
+        cfg = MetadataConfig()
+        cfg.metadata_list = ["url", "timestamp", "html", "entity"]
+        cfg.max_seq_len = 85
+        cfg.metadata_probability = 1
+        cfg.metadata_add_special_token_for_generation = True
+        cfg.metadata_special_token_for_generation_start_seq = " "
+        cfg.metadata_global_start_seq = " "
+        cfg.treat_local_metadata_as_regular_text = True
+
+        PROCESSORS["url"] = UrlProcessor
+        PROCESSORS["timestamp"] = TimestampProcessor
+        PROCESSORS["html"] = HtmlProcessor
+        PROCESSORS["entity"] = EntityProcessor
+
+        ds_dict = {
+            key: [self.examples[1][key], self.examples[4][key], self.examples[4][key]]
+            for key in self.examples[0].keys()
+        }
+        ds = Dataset.from_dict(ds_dict)
+
+        mapped_ds = ds.map(
+            functools.partial(add_metadata_and_chunk_examples, tokenizer=self.tokenizer, cfg=cfg),
+            batched=True,
+            remove_columns=ds.column_names,
+            load_from_cache_file=False,
+        )
+
+        self.maxDiff = None
+
+        self.assertEqual(
+            self.tokenizer.decode(mapped_ds[0]["input_ids"]),
+            " url html entity ||| url: https://en.wikipedia.org/wiki/Apple ||| An <b>apple [[Malus domestica]]</b> is an edible fruit produced by an <b class:level1><i class:level2>apple</i> tree</b> (Malus domestica).<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>",
+        )
+        self.assertEqual(
+            self.tokenizer.decode(mapped_ds[1]["input_ids"]),
+            " url html entity ||| url: https://en.wikipedia.org/wiki/Apple ||| An <b>apple [[Malus domestica]]</b> is an edible fruit produced by an <a></a><b class:level1><b class:level2><i class:level3><a></a>apple</i> tree</b></b> (Malus domestica).<|endoftext|>",
+        )
+        self.assertEqual(
+            self.tokenizer.decode(mapped_ds[2]["input_ids"]),
+            " url html entity ||| url: https://en.wikipedia.org/wiki/Apple ||| An <b>apple [[Malus domestica]]</b> is an edible fruit produced by an <a></a><b class:level1><b class:level2><i class:level3><a></a>apple</i> tree</b></b> (Malus domestica).<|endoftext|>",
+        )
+
+        # fmt: off
+        self.assertEqual(self.tokenizer.convert_ids_to_tokens(mapped_ds[0]["input_ids"]), ['Ġurl', 'Ġhtml', 'Ġentity', 'Ġ||', '|', 'Ġurl', ':', 'Ġhttps', '://', 'en', '.', 'wikipedia', '.', 'org', '/', 'wiki', '/', 'Apple', 'Ġ||', '|', 'ĠAn', 'Ġ<', 'b', '>', 'apple', 'Ġ[[', 'Mal', 'us', 'Ġdomest', 'ica', ']]', '</', 'b', '>', 'Ġis', 'Ġan', 'Ġedible', 'Ġfruit', 'Ġproduced', 'Ġby', 'Ġan', 'Ġ<', 'b', 'Ġclass', ':', 'level', '1', '><', 'i', 'Ġclass', ':', 'level', '2', '>', 'apple', '</', 'i', '>', 'Ġtree', '</', 'b', '>', 'Ġ(', 'Mal', 'us', 'Ġdomest', 'ica', ').', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>', '<|endoftext|>'])
+        self.assertEqual(self.tokenizer.convert_ids_to_tokens(mapped_ds[1]["input_ids"]), ['Ġurl', 'Ġhtml', 'Ġentity', 'Ġ||', '|', 'Ġurl', ':', 'Ġhttps', '://', 'en', '.', 'wikipedia', '.', 'org', '/', 'wiki', '/', 'Apple', 'Ġ||', '|', 'ĠAn', 'Ġ<', 'b', '>', 'apple', 'Ġ[[', 'Mal', 'us', 'Ġdomest', 'ica', ']]', '</', 'b', '>', 'Ġis', 'Ġan', 'Ġedible', 'Ġfruit', 'Ġproduced', 'Ġby', 'Ġan', 'Ġ<', 'a', '></', 'a', '><', 'b', 'Ġclass', ':', 'level', '1', '><', 'b', 'Ġclass', ':', 'level', '2', '><', 'i', 'Ġclass', ':', 'level', '3', '><', 'a', '></', 'a', '>', 'apple', '</', 'i', '>', 'Ġtree', '</', 'b', '></', 'b', '>', 'Ġ(', 'Mal', 'us', 'Ġdomest', 'ica', ').', '<|endoftext|>'])
+        self.assertEqual(self.tokenizer.convert_ids_to_tokens(mapped_ds[2]["input_ids"]), ['Ġurl', 'Ġhtml', 'Ġentity', 'Ġ||', '|', 'Ġurl', ':', 'Ġhttps', '://', 'en', '.', 'wikipedia', '.', 'org', '/', 'wiki', '/', 'Apple', 'Ġ||', '|', 'ĠAn', 'Ġ<', 'b', '>', 'apple', 'Ġ[[', 'Mal', 'us', 'Ġdomest', 'ica', ']]', '</', 'b', '>', 'Ġis', 'Ġan', 'Ġedible', 'Ġfruit', 'Ġproduced', 'Ġby', 'Ġan', 'Ġ<', 'a', '></', 'a', '><', 'b', 'Ġclass', ':', 'level', '1', '><', 'b', 'Ġclass', ':', 'level', '2', '><', 'i', 'Ġclass', ':', 'level', '3', '><', 'a', '></', 'a', '>', 'apple', '</', 'i', '>', 'Ġtree', '</', 'b', '></', 'b', '>', 'Ġ(', 'Mal', 'us', 'Ġdomest', 'ica', ').', '<|endoftext|>'])
+        # fmt: on
+
+
+        # fmt: off
+        self.assertEqual(mapped_ds[0]["metadata_mask"], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] )
+        self.assertEqual(mapped_ds[1]["metadata_mask"], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] )
+        self.assertEqual(mapped_ds[2]["metadata_mask"], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] )
         # fmt: on
 
 


### PR DESCRIPTION
# What does this PR do?

Implement the feature requested by issue #34 . This feature change the value of `metadata_mask`

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. 

FYI (local metadata), @manandey 