### PR TITLE
Add preprocessing utils interface.

### DIFF
--- a/bsmetadata/preprocessing_utils.py
+++ b/bsmetadata/preprocessing_utils.py
@@ -1,0 +1,54 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This script provides functions for adding different kinds of metadata to a pretraining corpus.
+"""
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional
+
+
+class MetadataPreprocessor(ABC):
+    """A metadata processor can be used for preprocessing text and adding or extracting metadata information."""
+
+    @abstractmethod
+    def preprocess(self, examples: Dict[str, List]) -> Dict[str, List]:
+        """Process a batch of examples and add or extract corresponding metadata."""
+        pass
+
+
+class TimestampPreprocessor(MetadataPreprocessor):
+    """An exemplary metadata preprocessor for adding timestamp information based on URLs."""
+
+    def preprocess(self, examples: Dict[str, List]) -> Dict[str, List]:
+
+        example_metadata_list = examples["metadata"]
+
+        # Iterate through the metadata associated with all examples in this batch.
+        for example_metadata in example_metadata_list:
+            # Get the URL associated with this example.
+            example_urls = [md["value"] for md in example_metadata if md["key"] == "url"]
+
+            if not example_urls:
+                continue
+
+            # Try to extract a timestamp from the given URL and add it to the metadata.
+            example_timestamp = self._extract_timestamp_from_url(example_urls[0])
+
+            if example_timestamp:
+                example_metadata.append({"key": "timestamp", "type": "global", "value": example_timestamp})
+
+        return examples
+
+    def _extract_timestamp_from_url(self, url: str) -> Optional:
+        # This would have to be implemented.
+        return None


### PR DESCRIPTION
This pull request is part of a proposal for how we can preprocess the C4 and Wikipedia datasets to get them into the format described [here](https://github.com/bigscience-workshop/metadata#metadata-format). Basically, everyone working on a specific kind of metadata would have to implement their own, metadata-specific `MetadataPreprocessor` which defines a single `preprocess` function that takes as input a set of examples and outputs the same set of examples, but with the particular metadata added.

The `preprocess` function is supposed to be used to perform [batch mapping](https://huggingface.co/docs/datasets/about_map_batch.html) with the `map` function from Huggingface's datasets. That is, on a high level, we'd do something like:

```python
ds = ... # load the original dataset, do some initial reformatting

for metadata_preprocessor in metadata_preprocessors:
    ds = ds.map(lambda ex: metadata_preprocessor.preprocess(ex), batched=True)
```

I have included in this pull request a simple example of how a preprocessor that extracts timestamp information based on available URLs may look like (see `TimestampPreprocessor` in `preprocessing_utils.py`).

It would be great if each of you could think about whether this particular interface suits all of your needs and whether it's easy to convert whatever you've been using before so that it is compatible with this interface.

@SaulLu: As HTML tags are quite different from other kinds of metadata we consider here (because adding HTML tags will involve modifying the actual input texts), it might make sense to think about whether we need a separate solution for them.
