### PR TITLE
Add timestamp processor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bsmetadata/vendor/dateutil"]
+	path = bsmetadata/vendor/dateutil
+	url = https://github.com/cccntu/dateutil

--- a/tests/test_parse_date.py
+++ b/tests/test_parse_date.py
@@ -1,10 +1,10 @@
 import unittest
 from datetime import datetime as DateTime
 
-from bsmetadata.preprocessing_utils import get_path_from_url, parse_date
+from bsmetadata.preprocessing_utils import TimestampPreprocessor, parse_date
 
 
-class TestDateutl(unittest.TestCase):
+class TestDateutil(unittest.TestCase):
     def test_parse_works(self):
         date = parse_date("2021/01/23/random text and num 123 asdf")
         self.assertTrue(date == DateTime(2021, 1, 23))
@@ -25,6 +25,17 @@ class TestDateutl(unittest.TestCase):
         date = parse_date("2021/01")
         self.assertTrue(date is None)
         date = parse_date("2021 jan")
+        self.assertTrue(date is None)
+
+
+class TestTimestampPreprocessor(unittest.TestCase):
+    def test_extract_timestamp_from_url(self):
+        processor = TimestampPreprocessor()
+        url = "https://www.nytimes.com/1998/03/08/sports/on-pro-basketball-one-last-hurrah-for-the-bulls-reinsdorf-isn-t-quite-saying.html"
+        date = processor._extract_timestamp_from_url(url)
+        self.assertEqual(date, "1998-03-08 00:00:00")
+        url = "https://www.nytimes.com/sports/on-pro-basketball-one-last-hurrah-for-the-bulls-reinsdorf-isn-t-quite-saying.html"
+        date = processor._extract_timestamp_from_url(url)
         self.assertTrue(date is None)
 
 

--- a/tests/test_parse_date.py
+++ b/tests/test_parse_date.py
@@ -1,0 +1,32 @@
+import unittest
+from datetime import datetime as DateTime
+
+from bsmetadata.preprocessing_utils import get_path_from_url, parse_date
+
+
+class TestDateutl(unittest.TestCase):
+    def test_parse_works(self):
+        date = parse_date("2021/01/23/random text and num 123 asdf")
+        self.assertTrue(date == DateTime(2021, 1, 23))
+        date = parse_date("2021/jan/23/random text and num 123 asdf")
+        self.assertTrue(date == DateTime(2021, 1, 23))
+        date = parse_date("2021/Jan/23/random text and num 123 asdf")
+        self.assertTrue(date == DateTime(2021, 1, 23))
+        date = parse_date("2021-jan-23 random text and num 123 asdf")
+        self.assertTrue(date == DateTime(2021, 1, 23))
+        date = parse_date("2021 jan 23 random text and num 123 asdf")
+        self.assertTrue(date == DateTime(2021, 1, 23))
+
+    def test_parse_fail_without_full_date(self):
+        date = parse_date("12")
+        self.assertTrue(date is None)
+        date = parse_date("2021")
+        self.assertTrue(date is None)
+        date = parse_date("2021/01")
+        self.assertTrue(date is None)
+        date = parse_date("2021 jan")
+        self.assertTrue(date is None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A few notes for discussion:

* I submodule my modified version of `dateutil` inside this repo, so there is no risk of messing up the dependency with `pip install -e`
* There are some mixed use of `import dateutil` and relative import in `dateutil`, but that doesn't seem to be an issue, so I left it that way.

## Alternative solution: regex


I tried to use a simple regex to parse, and find the difference with this version, and here are some of the dates the regex did not parse.

```python
r"(20[0-2][0-9]|19\d\d)[/\-](0?[1-9]|10|11|12)[/\-](0?[1-9]|[12]\d|3[01])"
```

```text
/news/2018/sep/24/community-calendar-sept-25-2018/
/entertainment/lehigh-valley-music/mc-ent-elvis-costello-review-sands-bethlehem-event-center-20181103-story.html
/news/2017/jan/01/births-announcements-part-ii-january-1-2016/
/articles/view/20180624/gozo/organ-masterclasses.682695
/nation-world/hc-wp-trump-racist-ad-20181102-story.html
/16-Apr-2019/sc-adjourns-hearing-of-orange-line-metro-train-case-till-friday
/news/20130731/project-gets-new-life-planned-condo-development-would-be-first-in-six-years-in-southeast-volusia
/news/20070510/mccheadlocal-sports-briefsmcchead/1
/stories/2018/may/29/harvard-study-estimates-thousands-died-in-puerto-r/
/sports/baseball/cubs/ct-kyle-schwarber-home-run-ball-wrigley-20160411-story.html
/environment/climate-change/huge-blow-backtoback-bleaching-covers-twothirds-of-the-great-barrier-reef-20170406-gvewah.html
/sports/20190103/young-beaver-girls-team-edged-by-avonworth-in-key-section-clash
/sports/report/serie-a-beaten-inters-lead-cut-juventus-napoli-win-easy/20151221.htm
/news/2017/apr/18/stringers-its-really-university-city-after-burner/
/sport/motorsport/stars-driven-around-the-bend-before-whincup-claims-pole-position-20180825-p4zzrc.html
/news/datablog/2011/oct/12/afghanistan-nato-kill-capture-raids-isaf-petraeus
/news/20071225/mccheadlocal-news-briefsmcchead/1
/business/realestate/hot-property/la-fi-hotprop-ellen-pompeo-hollywood-20171220-story.html
/sports/baseball/yankees/ny-sports-dallas-keuchel-yankees-free-agency-20181111-story.html
/news/politics/national/story/2015/may/24/fleischmann-already-pulling-big-dough/306023/
/national/western-australia/measles-alert-issued-for-perth-universities-public-transport-routes-20190201-p50v7t.html
/recap-11-05-2018-26629.html
/20121003/cleveland-county-building-permits/310039786
/archives/la-xpm-2010-jun-10-la-sp-0611-usc-ncaa-appeal-20100611-story.html
/archives/la-xpm-1998-sep-01-me-18472-story.html
```
That's ~16% less dates.
The urls are from this dataset:
https://huggingface.co/datasets/bs-modeling-metadata/c4_newslike_url_only

