### PR TITLE
Fix wandb config

### DIFF
--- a/bsmetadata/train.py
+++ b/bsmetadata/train.py
@@ -136,7 +136,8 @@ def loss_fn(batch, outputs, metadata_mask=None):
 
 @hydra.main(config_path=None, config_name="config")
 def main(args: CFG) -> None:
-    print(OmegaConf.to_yaml(args))
+    config_yaml = OmegaConf.to_yaml(args)
+    print(config_yaml)
 
     # The dataset library use the hash of the arguments to create the cache
     # name. Without this transformation the hash of args is not deterministic
@@ -230,7 +231,7 @@ def main(args: CFG) -> None:
 
     progress_bar = tqdm(range(args.max_train_steps), desc="training")
     completed_steps = 0
-    metrics_logger = Logger(is_local_main_process, project=args.project_name, config=args)
+    metrics_logger = Logger(is_local_main_process, project=args.project_name, config=config_yaml)
 
     do_eval = args.do_eval and args.start_with_eval
     if do_eval:

--- a/bsmetadata/train.py
+++ b/bsmetadata/train.py
@@ -136,8 +136,8 @@ def loss_fn(batch, outputs, metadata_mask=None):
 
 @hydra.main(config_path=None, config_name="config")
 def main(args: CFG) -> None:
-    config_yaml = OmegaConf.to_yaml(args)
-    print(config_yaml)
+    print(OmegaConf.to_yaml(args))
+    config_dict = OmegaConf.to_container(args)
 
     # The dataset library use the hash of the arguments to create the cache
     # name. Without this transformation the hash of args is not deterministic
@@ -231,7 +231,7 @@ def main(args: CFG) -> None:
 
     progress_bar = tqdm(range(args.max_train_steps), desc="training")
     completed_steps = 0
-    metrics_logger = Logger(is_local_main_process, project=args.project_name, config=config_yaml)
+    metrics_logger = Logger(is_local_main_process, project=args.project_name, config=config_dict)
 
     do_eval = args.do_eval and args.start_with_eval
     if do_eval:


### PR DESCRIPTION
The current way of passing config to wandb would cause parameteres in nested configs like 'data_config' to be displayed all in one field on wandb.

By passing a nested dictionary instead of dataclass, wandb will put each leaf in separate field.

Before:
```json
    "data_config": {
        "desc": null,
        "value": "DataConfig(metadata_config=MetadataConfig(metadata_list=[], local_metadata_special_tokens=None, metadata_sep=' | ', metadata_key_value_sep=': ' 
...
"
    },
```

After:
```json
    "data_config": {
        "desc": null,
        "value": {
            "metadata_config": {
                "metadata_sep": " | ",
                "metadata_list": [],
                "metadata_prefix_sep": " |||",
                "metadata_key_value_sep": ": ",
            },
...
```