### PR TITLE
fix: change `bs_dateuil` github dependency in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = req_file("requirements.txt")
 preprocessing_requires = {
     "html": ["lxml==4.6.3", "htmlmin==0.1.12"],
     "entity": ["REL @ git+https://github.com/manandey/REL.git#egg=REL"],
-    "timestamp": ["bs_dateutil @ git+git://github.com/cccntu/dateutil@2.8.5"],
+    "timestamp": ["bs_dateutil @ git+https://github.com/cccntu/dateutil.git@2.8.5"],
     "website_description": ["wikipedia2vec==1.0.5", "nltk==3.6.5"],
 }
 


### PR DESCRIPTION
When I tried to install the package on JZ, I got an error (a timeout error if I remember correctly).

I'm not absolutely sure, but I think that the `git+git://github.com/cccntu/dateutil@2.8.5` dependency requires an ssh setup to perform the installation. As I don't have an ssh setup with my github account on jz, I suggest to change the dependency declaration for `bs_dateuil` as this package is hosted on a public repository to use an https connection. With this modification, the installation is successful on JZ. :slightly_smiling_face: 