### PR TITLE
feat: add `dumpdb` toy script

### DIFF
--- a/experiments/jz/toy_experiments/README.md
+++ b/experiments/jz/toy_experiments/README.md
@@ -1,0 +1,4 @@
+The purpose of these scripts is to test in advance how to perform certain operations on JZ
+
+# DumpDB
+The scripts in the dumpdb folder allow to test the execution of the lmbd database which is used by `wikipedia2vec` (website description metadata) with a `.db` toy file 

--- a/experiments/jz/toy_experiments/dumpdb/dumpdb.py
+++ b/experiments/jz/toy_experiments/dumpdb/dumpdb.py
@@ -1,0 +1,21 @@
+import logging
+from wikipedia2vec.dump_db import DumpDB
+import argparse
+
+logger = logging.getLogger(__name__)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--path-to-dump", help="echo the string you use here")
+args = parser.parse_args()
+
+logger.info(f"using as args: {args}")
+
+dump_db = DumpDB(args.path_to_dump)
+
+logger.info("the loading of the database has succeed")
+
+redirects_map = {key.lower(): value for key, value in dump_db.redirects()}
+
+logger.info(f"`redirects_map` keys are {list(redirects_map.keys())}")
+
+data = dump_db.get_paragraphs(redirects_map["america"]).text[0]

--- a/experiments/jz/toy_experiments/dumpdb/dumpdb.py
+++ b/experiments/jz/toy_experiments/dumpdb/dumpdb.py
@@ -1,6 +1,8 @@
-import logging
-from wikipedia2vec.dump_db import DumpDB
 import argparse
+import logging
+
+from wikipedia2vec.dump_db import DumpDB
+
 
 logger = logging.getLogger(__name__)
 

--- a/experiments/jz/toy_experiments/dumpdb/dumpdb.slurm
+++ b/experiments/jz/toy_experiments/dumpdb/dumpdb.slurm
@@ -1,0 +1,28 @@
+#!/bin/bash
+#SBATCH --job-name=modelling-metadata-website-desc-create-dataset-25k  # job name
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1                                            # crucial - only 1 task per dist per node!
+#SBATCH --cpus-per-task=20                                             # number of cores per tasks
+#SBATCH --hint=nomultithread                                           # we get physical cores not logical
+#SBATCH --time 01:00:00                                                # maximum execution time (HH:MM:SS)
+#SBATCH --output=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.out  # output file name
+#SBATCH --error=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.err   # error file name
+#SBATCH --account=six@cpu # account
+
+set -x -e
+
+# Next line will:
+# - load a conda environment with the dependencies on the master branch of github.com/bigscience-workshop/metadata/
+# - setup env vars ($HOME, $WORK, etc)
+# - load several modules (git)
+# Note: We can afford to have two conda environments: one stable for running experiments and one for development.
+# If there are new dependencies to install, you have to tell me about them and not do it in this script
+source $HOME/start-modelling-metadata-user
+
+# Folder for the clone of github.com/bigscience-workshop/metadata/
+cd $WORK/repos/sync/metadata/
+
+# Now we launch the script that will perform the preprocessing of the dataset
+# Feel free to add any arguments you like (change me!)
+python experiments/jz/toy_experiments/dumpdb.py \
+    --path-to-dump "${SCRATCH}/tmp/en_wiki_new.db"


### PR DESCRIPTION
I open this PR to show you the script I ran for the moment on JZ to check that we could use `wikipedia2vec` which relies on the use of a `lmbd` database whose data are gathered in a `.db` file. I used for this test a toy database kindly shared by @shanyas10.

Good news @shanyas10 : everything works fine! :confetti_ball: 

@Timo, do we want to merge this kind of scripts on master? 
