### PR TITLE
fix: reduce try/except scope into `fetch_wikipedia_description_for_title`

### DIFF
--- a/bsmetadata/preprocessing_tools/website_desc_utils.py
+++ b/bsmetadata/preprocessing_tools/website_desc_utils.py
@@ -23,10 +23,12 @@ class WebsiteDescUtils:
     def fetch_wikipedia_description_for_title(self, title: str) -> Optional:
         try:
             text = self.wiki_dump_db.get_paragraphs(title)[0].text
-            text = re.sub(r"\((?:[^)(]|\([^)(]*\))*\)", "", text)
-            text = nltk.sent_tokenize(text)[0]  # Picking the first sentence
-        except Exception:
+        except KeyError:
+            # In case the title has not corresponding paragraph
             return None
+
+        text = re.sub(r"\((?:[^)(]|\([^)(]*\))*\)", "", text)
+        text = nltk.sent_tokenize(text)[0]  # Picking the first sentence
         return text
 
     def extract_wiki_desc(self, keyword: str) -> Optional:

--- a/bsmetadata/preprocessing_tools/website_desc_utils.py
+++ b/bsmetadata/preprocessing_tools/website_desc_utils.py
@@ -24,7 +24,7 @@ class WebsiteDescUtils:
         try:
             text = self.wiki_dump_db.get_paragraphs(title)[0].text
         except KeyError:
-            # In case the title has not corresponding paragraph
+            # If the title does not have a corresponding paragraph
             return None
 
         text = re.sub(r"\((?:[^)(]|\([^)(]*\))*\)", "", text)


### PR DESCRIPTION
As discussed offline with @shanyas10 , we need to have a try/except in the `fetch_wikipedia_description_for_title` method if the title is not in the database. 

On the other hand, we can be more precise on the type of error to be catched in order to have other types of errors raised (like for example when we forgot to install the punkt model necessary to`nltk.sent_tokenize`)