### PR TITLE
Add code to sampling multiple metadata

### DIFF
--- a/bsmetadata/experiments/with_metadata.py
+++ b/bsmetadata/experiments/with_metadata.py
@@ -5,7 +5,7 @@ from datasets import config, load_dataset
 from torch.utils.data import DataLoader
 from transformers import default_data_collator
 
-from bsmetadata.metadata_utils import add_metadata_and_chunk_examples
+from bsmetadata.metadata_utils import add_metadata_and_chunk_examples, random_drop_metadata
 
 
 logger = logging.getLogger(__name__)
@@ -118,6 +118,15 @@ def get_dataloaders(tokenizer, args):
     logger.info("Start to add metadata and chunk examples")
 
     # First we pre-process our text and metadata
+    if args.metadata_config.random_drop_metadata:
+        datasets = datasets.map(
+            random_drop_metadata,
+            batched=True,
+            num_proc=args.preprocessing_num_workers,
+            load_from_cache_file=not args.overwrite_cache,
+            desc="Randomly dropping metadata",
+            batch_size=args.map_batch_size,
+        )
     datasets = datasets.map(
         functools.partial(add_metadata_and_chunk_examples, tokenizer=tokenizer, cfg=args.metadata_config),
         batched=True,

--- a/bsmetadata/experiments/with_metadata.py
+++ b/bsmetadata/experiments/with_metadata.py
@@ -128,7 +128,7 @@ def get_dataloaders(tokenizer, args):
         )
     )
     metadata_type_weight_sum = sum(metadata_type_counter.values())
-    metadata_type_sample_weights = {k: v / metadata_type_weight_sum for k, v in metadata_type_counter.items()}
+    metadata_type_sample_weights = {k: metadata_type_weight_sum / v for k, v in metadata_type_counter.items()}
 
     # First we pre-process our text and metadata
     if args.metadata_config.random_sample_metadata:

--- a/bsmetadata/experiments/with_metadata.py
+++ b/bsmetadata/experiments/with_metadata.py
@@ -8,11 +8,7 @@ from torch.utils.data import DataLoader
 from tqdm.auto import tqdm
 from transformers import default_data_collator
 
-from bsmetadata.metadata_utils import (
-    add_metadata_and_chunk_examples,
-    add_metadata_types_column,
-    random_sample_metadata,
-)
+from bsmetadata.metadata_utils import add_metadata_and_chunk_examples, get_metadata_types, random_sample_metadata
 
 
 logger = logging.getLogger(__name__)
@@ -125,17 +121,9 @@ def get_dataloaders(tokenizer, args):
     logger.info("Start to add metadata and chunk examples")
 
     # get statistics of the dataset for sampling metadata
-    datasets = datasets.map(
-        add_metadata_types_column,
-        batched=True,
-        num_proc=args.preprocessing_num_workers,
-        load_from_cache_file=not args.overwrite_cache,
-        desc="Get metadata types",
-        batch_size=args.map_batch_size,
-    )
     metadata_type_counter = Counter(
         chain.from_iterable(
-            x["metadata_types"]
+            get_metadata_types(x["metadata"])
             for x in tqdm(datasets["train"], desc="iterate over training set to count metadata types")
         )
     )

--- a/bsmetadata/experiments/with_metadata.py
+++ b/bsmetadata/experiments/with_metadata.py
@@ -131,7 +131,7 @@ def get_dataloaders(tokenizer, args):
     metadata_type_sample_weights = {k: v / metadata_type_weight_sum for k, v in metadata_type_counter.items()}
 
     # First we pre-process our text and metadata
-    if args.metadata_config.random_drop_metadata:
+    if args.metadata_config.random_sample_metadata:
         datasets = datasets.map(
             functools.partial(random_sample_metadata, metadata_type_sample_weights=metadata_type_sample_weights),
             batched=True,

--- a/bsmetadata/metadata_processors.py
+++ b/bsmetadata/metadata_processors.py
@@ -47,6 +47,10 @@ class MetadataConfig:
         default=": ",
         metadata={"help": "The character sequence that is used by default to separate a metadata key and its value."},
     )
+    random_drop_metadata: bool = field(
+        default=False,
+        metadata={"help": "Whether to random drop metadata, using bsmetadata.metadata_utils.random_drop_metadata."},
+    )
     metadata_probability: float = field(
         default=1, metadata={"help": "The probability of adding metadata to an input example."}
     )

--- a/bsmetadata/metadata_processors.py
+++ b/bsmetadata/metadata_processors.py
@@ -47,9 +47,9 @@ class MetadataConfig:
         default=": ",
         metadata={"help": "The character sequence that is used by default to separate a metadata key and its value."},
     )
-    random_drop_metadata: bool = field(
+    random_sample_metadata: bool = field(
         default=False,
-        metadata={"help": "Whether to random drop metadata, using bsmetadata.metadata_utils.random_drop_metadata."},
+        metadata={"help": "Whether to random drop metadata, using bsmetadata.metadata_utils.random_sample_metadata."},
     )
     metadata_probability: float = field(
         default=1, metadata={"help": "The probability of adding metadata to an input example."}

--- a/bsmetadata/metadata_utils.py
+++ b/bsmetadata/metadata_utils.py
@@ -124,6 +124,33 @@ def add_metadata_and_chunk_examples(
     return linearized_examples
 
 
+def get_metadata_types(metadata_list):
+    return list(set(m["key"] for m in metadata_list))
+
+
+def random_drop_metadata(
+    examples: Dict[str, List],
+) -> Dict[str, List]:
+    """Randomly drop some of the metadata from the provided examples.
+    Uniformly decide the number of metadata to keep. And drop the metadata uniformly.
+
+    Args:
+        examples: The examples to process, with required keys "text" and "metadata".
+
+    Returns:
+        A new (potentially larger) collection of examples
+    """
+    new_metadata = []
+    for example_metadata_list in examples["metadata"]:
+        metadata_types = get_metadata_types(example_metadata_list)
+        num_metadata_to_keep = random.randint(0, len(metadata_types))
+        random.shuffle(metadata_types)
+        metadata_types = metadata_types[:num_metadata_to_keep]
+        new_metadata.append([m for m in example_metadata_list if m["key"] in metadata_types])
+    examples["metadata"] = new_metadata
+    return examples
+
+
 def create_metadata_prefix(example: Dict[str, Any], cfg: MetadataConfig) -> str:
     """Creates a prefix containing all global metadata information (including URLs, timestamps, etc)
     and/or local metadata special tokens

--- a/bsmetadata/metadata_utils.py
+++ b/bsmetadata/metadata_utils.py
@@ -144,12 +144,18 @@ def random_sample_metadata(
     """
     new_metadata = []
     for example_metadata_list in examples["metadata"]:
+        if not example_metadata_list:
+            new_metadata.append([])
+            continue
+
         metadata_types = get_metadata_types(example_metadata_list)
         num_metadata_to_keep = random.randint(1, len(metadata_types))
         vec = np.arange(len(metadata_types))
         if metadata_type_sample_weights is not None:
             weights = np.array([metadata_type_sample_weights[m] for m in metadata_types])
             weights = weights / weights.sum()
+        else:
+            weights = None
         metadata_types = np.random.choice(vec, num_metadata_to_keep, replace=False, p=weights)
         new_metadata.append([m for m in example_metadata_list if m["key"] in metadata_types])
     examples["metadata"] = new_metadata

--- a/bsmetadata/metadata_utils.py
+++ b/bsmetadata/metadata_utils.py
@@ -132,13 +132,13 @@ def random_drop_metadata(
     examples: Dict[str, List],
 ) -> Dict[str, List]:
     """Randomly drop some of the metadata from the provided examples.
-    Uniformly decide the number of metadata to keep. And drop the metadata uniformly.
+    Uniformly decide the number of metadata types to keep. And drop the metadata uniformly.
 
     Args:
-        examples: The examples to process, with required keys "text" and "metadata".
+        examples: The examples to process, with required "metadata".
 
     Returns:
-        A new (potentially larger) collection of examples
+        A new collection of examples, with some metadata dropped.
     """
     new_metadata = []
     for example_metadata_list in examples["metadata"]:

--- a/bsmetadata/metadata_utils.py
+++ b/bsmetadata/metadata_utils.py
@@ -129,20 +129,6 @@ def get_metadata_types(metadata_list):
     return list(set(m["key"] for m in metadata_list))
 
 
-def add_metadata_types_column(
-    examples: Dict[str, List],
-) -> Dict[str, List]:
-    """Adds a column with the metadata types to the provided examples.
-    Do this in batches to speed up the process.
-    """
-    examples_metadata_types = []
-    for example_metadata_list in examples["metadata"]:
-        metadata_types = get_metadata_types(example_metadata_list)
-        example_metadata_list.append(metadata_types)
-    examples["metadata_types"] = examples_metadata_types
-    return examples
-
-
 def random_sample_metadata(
     examples: Dict[str, List],
     metadata_type_sample_weights=None,
@@ -157,8 +143,6 @@ def random_sample_metadata(
         A new collection of examples, with some metadata dropped.
     """
     new_metadata = []
-    # TODO: use previously obtained `metadata_types` and pop metadata_types column after this function
-    # for example_metadata_list, metadata_types in zip(examples["metadata"], examples["metadata_types"]):
     for example_metadata_list in examples["metadata"]:
         metadata_types = get_metadata_types(example_metadata_list)
         num_metadata_to_keep = random.randint(1, len(metadata_types))

--- a/bsmetadata/metadata_utils.py
+++ b/bsmetadata/metadata_utils.py
@@ -156,7 +156,8 @@ def random_sample_metadata(
             weights = weights / weights.sum()
         else:
             weights = None
-        metadata_types = np.random.choice(vec, num_metadata_to_keep, replace=False, p=weights)
+        metadata_types_ids = np.random.choice(vec, num_metadata_to_keep, replace=False, p=weights)
+        metadata_types = [metadata_types[i] for i in metadata_types_ids]
         new_metadata.append([m for m in example_metadata_list if m["key"] in metadata_types])
     examples["metadata"] = new_metadata
     return examples


### PR DESCRIPTION
According to discussion with @timoschick . 
Added a function to sample metadata as follows:
1. uniformly decide how many types of metadata should be included.
2. randomly choose metadata types to include.

WIP: need to add test and add code to actually call this function.