### PR TITLE
change: retrieve the url from a column instead of from the metadata

### DIFF
--- a/bsmetadata/preprocessing_utils.py
+++ b/bsmetadata/preprocessing_utils.py
@@ -67,19 +67,13 @@ class TimestampPreprocessor(MetadataPreprocessor):
     """An exemplary metadata preprocessor for adding timestamp information based on URLs."""
 
     def preprocess(self, examples: Dict[str, List]) -> Dict[str, List]:
-
+        example_url_list = examples["url"]
         example_metadata_list = examples["metadata"]
 
         # Iterate through the metadata associated with all examples in this batch.
-        for example_metadata in example_metadata_list:
-            # Get the URL associated with this example.
-            example_urls = [md["value"] for md in example_metadata if md["key"] == "url"]
-
-            if not example_urls:
-                continue
-
+        for example_metadata, example_url in zip(example_metadata_list, example_url_list):
             # Try to extract a timestamp from the given URL and add it to the metadata.
-            example_timestamp = self._extract_timestamp_from_url(example_urls[0])
+            example_timestamp = self._extract_timestamp_from_url(example_url)
 
             if example_timestamp:
                 example_metadata.append({"key": "timestamp", "type": "global", "value": example_timestamp})
@@ -143,19 +137,13 @@ class WebsiteDescPreprocessor(MetadataPreprocessor):
         super().__init__()
 
     def preprocess(self, examples: Dict[str, List]) -> Dict[str, List]:
-
+        urls_list = examples["url"]
         metadata_list = examples["metadata"]
 
         # Iterate through the metadata associated with all examples in this batch.
-        for metadata in metadata_list:
-            # Get the URL associated with this example.
-            urls = [md["value"] for md in metadata if md["key"] == "url"]
-
-            if not urls:
-                continue
-
+        for metadata, url in zip(metadata_list, urls_list):
             # Try to extract a website description from the given URL and add it to the metadata.
-            website_description = self._extract_website_desc_from_url(urls[0])
+            website_description = self._extract_website_desc_from_url(url)
 
             if website_description:
                 metadata.append({"key": "website_description", "type": "global", "value": website_description})

--- a/tests/test_preprocessing_utils.py
+++ b/tests/test_preprocessing_utils.py
@@ -19,15 +19,25 @@ class WebsiteDescPreprocessorTester(unittest.TestCase):
         self.example_ids = [0, 1, 2]
         self.example_text = ["test text 1", "test text 2", "test text 3"]
         self.example_metadata = [
-            [{"key": "url", "type": "global", "value": "https://www.xyz.com"}],
+            [{"key": "prev_metadata", "type": "global", "value": "1"}],
             [
-                {"key": "url", "type": "global", "value": "http://sometitle.com"},
-                {"key": "url", "type": "global", "value": "http://notfound.com"},
+                {"key": "prev_metadata", "type": "global", "value": "2"},
+                {"key": "prev_metadata", "type": "global", "value": "3"},
             ],
-            [{"key": "url", "type": "global", "value": "https://www.test.com"}],
+            [{"key": "prev_metadata", "type": "global", "value": "4"}],
+        ]
+        self.url = [
+            "https://www.xyz.com",
+            "http://sometitle.com",
+            "https://www.test.com",
         ]
 
-        self.example_dict = {"id": self.example_ids, "metadata": self.example_metadata, "text": self.example_text}
+        self.example_dict = {
+            "id": self.example_ids,
+            "metadata": self.example_metadata,
+            "text": self.example_text,
+            "url": self.url,
+        }
 
     @mock.patch("bsmetadata.preprocessing_tools.wikipedia_desc_utils.nltk.sent_tokenize", new=mock_sent_tokenize)
     def test_website_metadata_processor(self):
@@ -35,16 +45,16 @@ class WebsiteDescPreprocessorTester(unittest.TestCase):
         ds = ds.map(lambda ex: self.website_processor.preprocess(ex), batched=True)
         target_metadata = [
             [
-                {"key": "url", "type": "global", "value": "https://www.xyz.com"},
+                {"key": "prev_metadata", "type": "global", "value": "1"},
                 {"key": "website_description", "type": "global", "value": "XYZ is a U.S. based company."},
             ],
             [
-                {"key": "url", "type": "global", "value": "http://sometitle.com"},
-                {"key": "url", "type": "global", "value": "http://notfound.com"},
+                {"key": "prev_metadata", "type": "global", "value": "2"},
+                {"key": "prev_metadata", "type": "global", "value": "3"},
                 {"key": "website_description", "type": "global", "value": "SomeTitle is a U.S. based company."},
             ],
             [
-                {"key": "url", "type": "global", "value": "https://www.test.com"},
+                {"key": "prev_metadata", "type": "global", "value": "4"},
                 {"key": "website_description", "type": "global", "value": "Test is a U.S. based company."},
             ],
         ]


### PR DESCRIPTION
As the dataset we are building has a column with the url of each document (cc @tianjianjiang ), I suggest that we look for the url in this column rather than in the metadata column (this will be faster).

@shanyas10 and @cccntu  is that ok?

cc @timoschick for visibility