### PR TITLE
feat: change how the entity extraction process use ids

### DIFF
--- a/bsmetadata/preprocessing_utils.py
+++ b/bsmetadata/preprocessing_utils.py
@@ -220,14 +220,14 @@ class EntityPreprocessor(
         for example_id, example_metadata in enumerate(examples["metadata"]):
             if example_id not in mentions_predicted:
                 continue
-            
+
             # fetch all the elements for which entity tags are present by mapping through "id"
             mentions_predicted_for_id = mentions_predicted[example_id]
             for mention_predicted in mentions_predicted_for_id:
                 # element at index = 3 in the result list corresponds to the predicted entity
-                entity = mention_predicted[3]  
+                entity = mention_predicted[3]
                 # element at index = 0 in the result list corresponds to the char start ind
-                char_start_idx = mention_predicted[0] 
+                char_start_idx = mention_predicted[0]
                 # element at index = 1 in the result list corresponds to length of the entity
                 char_end_idx = mention_predicted[0] + mention_predicted[1]
 
@@ -235,8 +235,8 @@ class EntityPreprocessor(
                 en = {
                     "key": "entity",
                     "type": "local",
-                    "char_start_idx": char_start_idx, 
-                    "char_end_idx": char_end_idx,  
+                    "char_start_idx": char_start_idx,
+                    "char_end_idx": char_end_idx,
                     "value": entity,
                     "ent_desc": ent_desc,
                 }

--- a/bsmetadata/preprocessing_utils.py
+++ b/bsmetadata/preprocessing_utils.py
@@ -188,13 +188,7 @@ class EntityPreprocessor(
 
     def preprocess_example(self, examples: Dict[str, List]) -> Dict[str, List]:
         # preprocess all the examples in a particular batch in the required format
-        processed = {}
-        for example_id, example_text in zip(examples["id"], examples["text"]):
-            id_ = example_id
-            text_ = example_text
-            value = [text_, []]
-            d = {id_: value}
-            processed.update(d)
+        processed = {ex_id: [ex_text, []] for ex_id, ex_text in enumerate(examples["text"])}
         return processed
 
     def fetch_mention_predictions(self, examples: Dict[str, List]) -> Dict[str, List]:
@@ -214,27 +208,30 @@ class EntityPreprocessor(
 
     def preprocess(self, examples: Dict[str, List]) -> Dict[str, List]:
         # process all the examples in a particular batch and all the metadata extracted for entities for those examples
+        mentions_predicted = self.fetch_mention_predictions(examples)
 
-        res = self.fetch_mention_predictions(examples)
+        for example_id, example_metadata in enumerate(examples["metadata"]):
+            if example_id not in mentions_predicted:
+                continue
+            
+            # fetch all the elements for which entity tags are present by mapping through "id"
+            mentions_predicted_for_id = mentions_predicted[example_id]
+            for mention_predicted in mentions_predicted_for_id:
+                # element at index = 3 in the result list corresponds to the predicted entity
+                entity = mention_predicted[3]  
+                # element at index = 0 in the result list corresponds to the char start ind
+                char_start_idx = mention_predicted[0] 
+                # element at index = 1 in the result list corresponds to length of the entity
+                char_end_idx = mention_predicted[0] + mention_predicted[1]
 
-        for example_id, example_metadata in zip(examples["id"], examples["metadata"]):
-            if example_id in res:  # fetch all the elements for which entity tags are present by mapping through "id"
-                r = res[example_id]
-                for i in range(len(r)):
-                    entity = r[i][3]  # element at index = 3 in the result list corresponds to the predicted entity
-                    ent_desc = self._extract_desc_from_entity(entity)
-                    en = {
-                        "key": "entity",
-                        "type": "local",
-                        "char_start_idx": r[i][
-                            0
-                        ],  # element at index = 0 in the result list corresponds to the char start index
-                        "char_end_idx": (
-                            r[i][0] + r[i][1]
-                        ),  # element at index = 1 in the result list corresponds to length of the entity
-                        "value": entity,
-                        "ent_desc": ent_desc,
-                    }
-                    example_metadata.append(en)
-            continue
+                ent_desc = self._extract_desc_from_entity(entity)
+                en = {
+                    "key": "entity",
+                    "type": "local",
+                    "char_start_idx": char_start_idx, 
+                    "char_end_idx": char_end_idx,  
+                    "value": entity,
+                    "ent_desc": ent_desc,
+                }
+                example_metadata.append(en)
         return examples

--- a/tests/test_entity_preprocessor.py
+++ b/tests/test_entity_preprocessor.py
@@ -80,9 +80,9 @@ class TestEntityPreprocessor(unittest.TestCase):
             [],
         ]
         processor = EntityPreprocessor(
-            base_url="/gpfsssd/scratch/rech/six/uue59kq/modeling-metadata-artefacts/entity_preprocessing",
-            path_wiki_db="/gpfsscratch/rech/six/uue59kq/modeling-metadata-artefacts/wiki_en_dump.db",
-            path_or_url_flair_ner_model="/gpfsscratch/rech/six/uue59kq/cache_dir/flair/ner-fast/en-ner-fast-conll03-v0.4.pt",
+            base_url="Enter the path to the folder having the files downloaded after running the bsmetadata\preprocessing_scripts\download_entity_processing_files.sh script",
+            path_wiki_db="Enter the path where the wiki_en_dump.db file is located",
+            path_or_url_flair_ner_model="Enter the path where you runned `wget https://nlp.informatik.hu-berlin.de/resources/models/ner-fast/en-ner-fast-conll03-v0.4.pt`",
         )
 
         ds = Dataset.from_dict(my_dict)

--- a/tests/test_entity_preprocessor.py
+++ b/tests/test_entity_preprocessor.py
@@ -68,8 +68,9 @@ class TestEntityPreprocessor(unittest.TestCase):
             [],
         ]
         processor = EntityPreprocessor(
-            "Enter the path to the folder having the files downloaded after running the bsmetadata\preprocessing_scripts\download_entity_processing_files.sh script",
-            "Enter the path where the wiki_en_dump.db file is located",
+            base_url="/gpfsscratch/rech/six/uue59k/modeling-metadata-artefacts/entity_preprocessing",
+            path_wiki_db="/gpfsscratch/rech/six/uue59kq/modeling-metadata-artefacts/wiki_en_dump.db",
+            path_or_url_flair_ner_model="/gpfsscratch/rech/six/uue59kq/cache_dir/flair/ner-fast/en-ner-fast-conll03-v0.4.pt",
         )
 
         ds = Dataset.from_dict(my_dict)

--- a/tests/test_entity_preprocessor.py
+++ b/tests/test_entity_preprocessor.py
@@ -9,7 +9,6 @@ class TestEntityPreprocessor(unittest.TestCase):
     def test_extract_entities(self):
 
         my_dict = {
-            "id": [0, 1, 2, 3],
             "text": [
                 "Paris is the beautiful place to visit",
                 "This Friday, Obama and Merkel will be meeting to discuss on issues related to climate change",
@@ -19,7 +18,6 @@ class TestEntityPreprocessor(unittest.TestCase):
             "metadata": [[], [], [], []],
         }  # toy dataset
 
-        target_id = [0, 1, 2, 3]
 
         target_text = [
             "Paris is the beautiful place to visit",
@@ -77,7 +75,6 @@ class TestEntityPreprocessor(unittest.TestCase):
         ds = Dataset.from_dict(my_dict)
         ds = ds.map(lambda ex: processor.preprocess(ex), batched=True, batch_size=3)
 
-        self.assertEqual(ds[:]["id"], target_id)
         self.assertEqual(ds[:]["text"], target_text)
         self.assertEqual(ds[:]["metadata"], target_metadata)
 

--- a/tests/test_entity_preprocessor.py
+++ b/tests/test_entity_preprocessor.py
@@ -19,7 +19,6 @@ class TestEntityPreprocessor(unittest.TestCase):
             "metadata": [[], [], [], [], []],
         }  # toy dataset
 
-
         target_text = [
             "Paris is the beautiful place to visit",
             "This Friday, Obama and Merkel will be meeting to discuss on issues related to climate change",
@@ -90,6 +89,7 @@ class TestEntityPreprocessor(unittest.TestCase):
 
         self.assertEqual(ds[:]["text"], target_text)
         self.assertEqual(ds[:]["metadata"], target_metadata)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_entity_preprocessor.py
+++ b/tests/test_entity_preprocessor.py
@@ -13,9 +13,10 @@ class TestEntityPreprocessor(unittest.TestCase):
                 "Paris is the beautiful place to visit",
                 "This Friday, Obama and Merkel will be meeting to discuss on issues related to climate change",
                 "Bieber performed at the concert last night",
+                "Paris is the beautiful place to visit",
                 "He was playing a game",
             ],
-            "metadata": [[], [], [], []],
+            "metadata": [[], [], [], [], []],
         }  # toy dataset
 
 
@@ -23,6 +24,7 @@ class TestEntityPreprocessor(unittest.TestCase):
             "Paris is the beautiful place to visit",
             "This Friday, Obama and Merkel will be meeting to discuss on issues related to climate change",
             "Bieber performed at the concert last night",
+            "Paris is the beautiful place to visit",
             "He was playing a game",
         ]
 
@@ -65,10 +67,20 @@ class TestEntityPreprocessor(unittest.TestCase):
                     "value": "Justin_Bieber",
                 }
             ],
+            [
+                {
+                    "char_end_idx": 5,
+                    "char_start_idx": 0,
+                    "ent_desc": "Paris  is the capital and most populous city of France, with an estimated population of 2,175,601 residents , in an area of more than .",
+                    "key": "entity",
+                    "type": "local",
+                    "value": "Paris",
+                }
+            ],
             [],
         ]
         processor = EntityPreprocessor(
-            base_url="/gpfsscratch/rech/six/uue59k/modeling-metadata-artefacts/entity_preprocessing",
+            base_url="/gpfsssd/scratch/rech/six/uue59kq/modeling-metadata-artefacts/entity_preprocessing",
             path_wiki_db="/gpfsscratch/rech/six/uue59kq/modeling-metadata-artefacts/wiki_en_dump.db",
             path_or_url_flair_ner_model="/gpfsscratch/rech/six/uue59kq/cache_dir/flair/ner-fast/en-ner-fast-conll03-v0.4.pt",
         )
@@ -78,7 +90,6 @@ class TestEntityPreprocessor(unittest.TestCase):
 
         self.assertEqual(ds[:]["text"], target_text)
         self.assertEqual(ds[:]["metadata"], target_metadata)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Before this PR, the extraction of named entities required an "id" column, I propose with this PR to generate on the fly the ids needed for batching in the REL library. This feature allows to avoid having to design an ids column upstream.

cc @timoschick , @norakassner 