### PR TITLE
feat: add a feature to choose where to extract metadata

### DIFF
--- a/bsmetadata/preprocessing_utils.py
+++ b/bsmetadata/preprocessing_utils.py
@@ -313,6 +313,7 @@ class EntityPreprocessor(
         examples[self.col_to_store_metadata] = example_metadata_list
         return examples
 
+
 class GenerationLengthPreprocessor(MetadataPreprocessor):
     """An exemplary metadata preprocessor for adding generation length information based on text."""
 

--- a/bsmetadata/preprocessing_utils.py
+++ b/bsmetadata/preprocessing_utils.py
@@ -299,7 +299,6 @@ class EntityPreprocessor(
                 char_end_idx = mention_predicted[0] + mention_predicted[1]
 
                 ent_desc = self._extract_desc_from_entity(entity)
-                print("ent_desc", ent_desc, "entity", entity)
                 en = {
                     "key": "entity",
                     "type": "local",

--- a/bsmetadata/preprocessing_utils.py
+++ b/bsmetadata/preprocessing_utils.py
@@ -69,29 +69,6 @@ class MetadataPreprocessor(ABC):
         pass
 
 
-class UrlPreprocessor(MetadataPreprocessor):
-    """An exemplary metadata preprocessor for adding timestamp information based on URLs."""
-
-    def __init__(self, col_to_store_metadata="metadata", col_url="url") -> None:
-        self.col_url = col_url
-        super().__init__(col_to_store_metadata=col_to_store_metadata)
-
-    def preprocess(self, examples: Dict[str, List]) -> Dict[str, List]:
-        example_metadata_list = (
-            examples[self.col_to_store_metadata]
-            if self.col_to_store_metadata in examples
-            else [[] for _ in range(len(examples[self.col_url]))]
-        )
-
-        # Iterate through the metadata associated with all examples in this batch.
-        for example_url, example_metadata in zip(examples[self.col_url], example_metadata_list):
-            if example_url:
-                example_metadata.append({"key": "url", "type": "global", "value": example_url})
-
-        examples[self.col_to_store_metadata] = example_metadata_list
-        return examples
-
-
 class TimestampPreprocessor(MetadataPreprocessor):
     """An exemplary metadata preprocessor for adding timestamp information based on URLs."""
 
@@ -463,6 +440,29 @@ class DatasourcePreprocessor(MetadataPreprocessor):
                 continue
 
             example_metadata.append({"key": "datasource", "type": "global", "value": example_datasource})
+
+        examples[self.col_to_store_metadata] = example_metadata_list
+        return examples
+
+
+class UrlPreprocessor(MetadataPreprocessor):
+    """An exemplary metadata preprocessor for adding timestamp information based on URLs."""
+
+    def __init__(self, col_to_store_metadata="metadata", col_url="url") -> None:
+        self.col_url = col_url
+        super().__init__(col_to_store_metadata=col_to_store_metadata)
+
+    def preprocess(self, examples: Dict[str, List]) -> Dict[str, List]:
+        example_metadata_list = (
+            examples[self.col_to_store_metadata]
+            if self.col_to_store_metadata in examples
+            else [[] for _ in range(len(examples[self.col_url]))]
+        )
+
+        # Iterate through the metadata associated with all examples in this batch.
+        for example_url, example_metadata in zip(examples[self.col_url], example_metadata_list):
+            if example_url:
+                example_metadata.append({"key": "url", "type": "global", "value": example_url})
 
         examples[self.col_to_store_metadata] = example_metadata_list
         return examples

--- a/bsmetadata/preprocessing_utils.py
+++ b/bsmetadata/preprocessing_utils.py
@@ -345,20 +345,14 @@ class GenerationLengthPreprocessor(MetadataPreprocessor):
             if self.mode == "text":
                 text_length = self._extract_length_from_text(example_text)
                 example_length = {"key": "length", "type": "global", "value": text_length}
+                if not example_length:
+                    continue
+                example_metadata.append(example_length)
             elif self.mode == "sentence":
                 example_length = self._extract_length_from_sentences(example_text)
+                example_metadata.extend(example_length)
             else:
                 print("Please select a valid length type [text or sentence].")
-
-            if not example_length:
-                continue
-
-            example_metadata.append(example_length)
-        example_metadata_list = (
-            [m[0] for m in example_metadata_list]
-            if self.mode == "sentence"
-            else example_metadata_list
-        )  # reformatting of nested lists
 
         examples[self.col_to_store_metadata] = example_metadata_list
         return examples

--- a/tests/mocks/mock_dump_db.py
+++ b/tests/mocks/mock_dump_db.py
@@ -9,7 +9,7 @@ class MockParagraph:
 class MockDumpDB:
     def __init__(self, db_file) -> None:
         self.db_file = db_file
-        self.redirect_info = [("xyz.com", "XYZ"), ("test.com", "Test"), ("test_key", "Test Key")]
+        self.redirect_info = [('barack obama','barack obama'),("xyz.com", "XYZ"), ("test.com", "Test"), ("test_key", "Test Key")]
         self.paragraphs_map = {
             "XYZ": [
                 MockParagraph("XYZ is a U.S. based company."),
@@ -23,6 +23,9 @@ class MockDumpDB:
                 MockParagraph("SomeTitle is a U.S. based company."),
                 MockParagraph("Test paragraph for the key SomeTitle."),
             ],
+            'barack obama':[
+                MockParagraph("Barack Hussein Obama II is an American politician."),
+            ]
         }
 
     def redirects(self) -> List[tuple]:

--- a/tests/mocks/mock_dump_db.py
+++ b/tests/mocks/mock_dump_db.py
@@ -9,7 +9,12 @@ class MockParagraph:
 class MockDumpDB:
     def __init__(self, db_file) -> None:
         self.db_file = db_file
-        self.redirect_info = [('barack obama','barack obama'),("xyz.com", "XYZ"), ("test.com", "Test"), ("test_key", "Test Key")]
+        self.redirect_info = [
+            ("barack obama", "barack obama"),
+            ("xyz.com", "XYZ"),
+            ("test.com", "Test"),
+            ("test_key", "Test Key"),
+        ]
         self.paragraphs_map = {
             "XYZ": [
                 MockParagraph("XYZ is a U.S. based company."),
@@ -23,9 +28,9 @@ class MockDumpDB:
                 MockParagraph("SomeTitle is a U.S. based company."),
                 MockParagraph("Test paragraph for the key SomeTitle."),
             ],
-            'barack obama':[
+            "barack obama": [
                 MockParagraph("Barack Hussein Obama II is an American politician."),
-            ]
+            ],
         }
 
     def redirects(self) -> List[tuple]:

--- a/tests/test_preprocessing_utils.py
+++ b/tests/test_preprocessing_utils.py
@@ -7,6 +7,7 @@ from mocks.mock_dump_db import MockDumpDB
 from bsmetadata.preprocessing_tools.wikipedia_desc_utils import WikipediaDescUtils
 from bsmetadata.preprocessing_utils import (
     EntityPreprocessor,
+    GenerationLengthPreprocessor,
     HtmlPreprocessor,
     TimestampPreprocessor,
     UrlPreprocessor,
@@ -394,7 +395,7 @@ class PipelinePreprocessorTester(unittest.TestCase):
             ],
         ]
 
-    target_metadata_entities = [
+        self.target_metadata_entities = [
         [],
         [
             {
@@ -440,6 +441,7 @@ class PipelinePreprocessorTester(unittest.TestCase):
         col_to_store_metadata_timestamp = "metadata_timestamp"
         col_to_store_metadata_website_desc = "metadata_website_desc"
         col_to_store_metadata_entities = "metadata_entity"
+        col_to_store_metadata_generation_length = "metadata_generation_length"
 
         html_processor = HtmlPreprocessor(
             col_to_store_metadata=col_to_store_metadata_html, col_to_store_text=col_to_store_text
@@ -454,6 +456,9 @@ class PipelinePreprocessorTester(unittest.TestCase):
         entity_processor = EntityPreprocessor(
             base_url="", path_wiki_db="", col_to_store_metadata=col_to_store_metadata_entities
         )
+        generation_length_preprocessor = GenerationLengthPreprocessor(
+            mode="sentence", col_to_store_metadata=col_to_store_metadata_generation_length
+        )
 
         # Apply function
         ds = Dataset.from_dict(self.init_dict)
@@ -462,6 +467,7 @@ class PipelinePreprocessorTester(unittest.TestCase):
         ds = ds.map(lambda ex: timestamp_processor.preprocess(ex), batched=True, batch_size=3)
         ds = ds.map(lambda ex: website_processor.preprocess(ex), batched=True, batch_size=3)
         ds = ds.map(lambda ex: entity_processor.preprocess(ex), batched=True, batch_size=3)
+        ds = ds.map(lambda ex: generation_length_preprocessor.preprocess(ex), batched=True, batch_size=3)
 
         self.assertEqual(ds[:][col_to_store_text], self.target_texts)
         self.assertEqual(ds[:][col_to_store_metadata_html], self.target_metadata_html)
@@ -469,6 +475,8 @@ class PipelinePreprocessorTester(unittest.TestCase):
         self.assertEqual(ds[:][col_to_store_metadata_timestamp], self.target_metadata_timestamp)
         self.assertEqual(ds[:][col_to_store_metadata_website_desc], self.target_metadata_website_desc)
         self.assertEqual(ds[:][col_to_store_metadata_entities], self.target_metadata_entities)
+
+        print(ds[:][col_to_store_metadata_generation_length])
 
         ds.set_format("pandas")
         print(ds[:])

--- a/tests/test_preprocessing_utils.py
+++ b/tests/test_preprocessing_utils.py
@@ -3,8 +3,8 @@ from unittest import mock
 
 from datasets import Dataset, Features, Value
 from mocks.mock_dump_db import MockDumpDB
-from bsmetadata.preprocessing_tools.wikipedia_desc_utils import WikipediaDescUtils
 
+from bsmetadata.preprocessing_tools.wikipedia_desc_utils import WikipediaDescUtils
 from bsmetadata.preprocessing_utils import (
     EntityPreprocessor,
     HtmlPreprocessor,

--- a/tests/test_preprocessing_utils.py
+++ b/tests/test_preprocessing_utils.py
@@ -404,7 +404,7 @@ class PipelinePreprocessorTester(unittest.TestCase):
                 "key": "entity",
                 "type": "local",
                 "value": "Barack_Obama",
-                "ent_desc": "Barack Hussein Obama II is an American politician."
+                "ent_desc": "Barack Hussein Obama II is an American politician.",
             },
             {
                 "char_end_idx": 48,
@@ -504,7 +504,6 @@ class PipelinePreprocessorTester(unittest.TestCase):
 
         features = Features(
             {
-                
                 "doc_html": Value("string"),
                 "metadata": [
                     {
@@ -519,7 +518,6 @@ class PipelinePreprocessorTester(unittest.TestCase):
                         "ent_desc": Value("string"),
                     }
                 ],
-                
                 "text": Value("string"),
                 "url": Value("string"),
             }

--- a/tests/test_preprocessing_utils.py
+++ b/tests/test_preprocessing_utils.py
@@ -1,6 +1,6 @@
-from typing import Dict, List
 import itertools
 import unittest
+from typing import Dict, List
 from unittest import mock
 
 from datasets import Dataset, Features, Value

--- a/tests/test_preprocessing_utils.py
+++ b/tests/test_preprocessing_utils.py
@@ -243,8 +243,8 @@ class PipelinePreprocessorTester(unittest.TestCase):
         self.init_dict = {
             "doc_html": [
                 "\n    <html>\n    <head>\n    </head>\n    <body>\n    <h1>This is a title</h1>\n    </body>\n    </html>\n",
-                "<html><body><p>this is a simple paragraph with Obama and Merkel mentioned </p></body></html>",
-                "<html><body><p id=1>paragraph 1</p><p id=2>paragraph 2 is in Paris</p></body></html>",
+                "<html><body><p>this is a simple paragraph with Obama and Merkel mentioned.</p></body></html>",
+                "<html><body><p id=1>paragraph 1.</p><p id=2>paragraph 2 is in Paris.</p></body></html>",
                 '<html><body><div class="div-level-1">blablabla<div class="div-level-2">tidi tidi</div></div></body></html>',
             ],
             "url": [
@@ -258,8 +258,8 @@ class PipelinePreprocessorTester(unittest.TestCase):
         # Define target values
         self.target_texts = [
             "This is a title\n",
-            "this is a simple paragraph with Obama and Merkel mentioned\n",
-            "paragraph 1\nparagraph 2 is in Paris\n",
+            "this is a simple paragraph with Obama and Merkel mentioned.\n",
+            "paragraph 1.\nparagraph 2 is in Paris.\n",
             "blablabla\ntidi tidi\n",
         ]
 
@@ -329,11 +329,11 @@ class PipelinePreprocessorTester(unittest.TestCase):
                     "value": "p",
                 },
                 {
-                    "char_end_idx": 59,
+                    "char_end_idx": 60,
                     "char_start_idx": 0,
                     "html_attrs": {"attrs": [], "values": []},
                     "key": "html",
-                    "relative_end_pos": 1,
+                    "relative_end_pos": 0,
                     "relative_start_pos": 0,
                     "type": "local",
                     "value": "body",
@@ -341,7 +341,7 @@ class PipelinePreprocessorTester(unittest.TestCase):
             ],
             [
                 {
-                    "char_end_idx": 11,
+                    "char_end_idx": 12,
                     "char_start_idx": 0,
                     "html_attrs": {"attrs": ["id"], "values": ["1"]},
                     "key": "html",
@@ -351,8 +351,8 @@ class PipelinePreprocessorTester(unittest.TestCase):
                     "value": "p",
                 },
                 {
-                    "char_end_idx": 35,
-                    "char_start_idx": 12,
+                    "char_end_idx": 37,
+                    "char_start_idx": 13,
                     "html_attrs": {"attrs": ["id"], "values": ["2"]},
                     "key": "html",
                     "relative_end_pos": 0,
@@ -361,7 +361,7 @@ class PipelinePreprocessorTester(unittest.TestCase):
                     "value": "p",
                 },
                 {
-                    "char_end_idx": 36,
+                    "char_end_idx": 38,
                     "char_start_idx": 0,
                     "html_attrs": {"attrs": [], "values": []},
                     "key": "html",
@@ -417,8 +417,8 @@ class PipelinePreprocessorTester(unittest.TestCase):
         ],
         [
             {
-                "char_end_idx": 35,
-                "char_start_idx": 30,
+                "char_end_idx": 36,
+                "char_start_idx": 31,
                 "ent_desc": "",
                 "key": "entity",
                 "type": "local",
@@ -468,7 +468,7 @@ class PipelinePreprocessorTester(unittest.TestCase):
         ds = ds.map(lambda ex: website_processor.preprocess(ex), batched=True, batch_size=3)
         ds = ds.map(lambda ex: entity_processor.preprocess(ex), batched=True, batch_size=3)
         ds = ds.map(lambda ex: generation_length_preprocessor.preprocess(ex), batched=True, batch_size=3)
-
+        self.maxDiff = None
         self.assertEqual(ds[:][col_to_store_text], self.target_texts)
         self.assertEqual(ds[:][col_to_store_metadata_html], self.target_metadata_html)
         self.assertEqual(ds[:][col_to_store_metadata_url], self.target_metadata_url)

--- a/tests/test_preprocessing_utils.py
+++ b/tests/test_preprocessing_utils.py
@@ -400,7 +400,6 @@ class PipelinePreprocessorTester(unittest.TestCase):
             {
                 "char_end_idx": 37,
                 "char_start_idx": 32,
-                "ent_desc": "",
                 "key": "entity",
                 "type": "local",
                 "value": "Barack_Obama",

--- a/tests/test_preprocessing_utils.py
+++ b/tests/test_preprocessing_utils.py
@@ -589,8 +589,18 @@ class PipelinePreprocessorTester(unittest.TestCase):
         ds = ds.map(lambda ex: timestamp_processor.preprocess(ex), batched=True, batch_size=3, features=features)
         ds = ds.map(lambda ex: website_processor.preprocess(ex), batched=True, batch_size=3, features=features)
         ds = ds.map(lambda ex: entity_processor.preprocess(ex), batched=True, batch_size=3, features=features)
-        ds = ds.map(lambda ex: generation_length_preprocessor_text.preprocess(ex), batched=True, batch_size=3, features=features)
-        ds = ds.map(lambda ex: generation_length_preprocessor_sentence.preprocess(ex), batched=True, batch_size=3, features=features)
+        ds = ds.map(
+            lambda ex: generation_length_preprocessor_text.preprocess(ex),
+            batched=True,
+            batch_size=3,
+            features=features,
+        )
+        ds = ds.map(
+            lambda ex: generation_length_preprocessor_sentence.preprocess(ex),
+            batched=True,
+            batch_size=3,
+            features=features,
+        )
         ds = ds.map(lambda ex: datasource_preprocessor.preprocess(ex), batched=True, batch_size=3, features=features)
 
         self.assertEqual(ds[:][col_to_store_text], self.target_texts)
@@ -668,7 +678,7 @@ class PipelinePreprocessorTester(unittest.TestCase):
                     }
                 )
                 self.assertIn(metadata, ds[id][col_to_store_metadata_generation_length_sentence])
-                
+
         for id, metadata_example in enumerate(self.target_metadata_length_text):
             for metadata in metadata_example:
                 metadata.update(

--- a/tests/test_preprocessing_utils.py
+++ b/tests/test_preprocessing_utils.py
@@ -4,7 +4,12 @@ from unittest import mock
 from datasets import Dataset
 from mocks.mock_dump_db import MockDumpDB
 
-from bsmetadata.preprocessing_utils import HtmlPreprocessor, WebsiteDescPreprocessor
+from bsmetadata.preprocessing_utils import (
+    HtmlPreprocessor,
+    TimestampPreprocessor,
+    UrlPreprocessor,
+    WebsiteDescPreprocessor,
+)
 
 
 def mock_sent_tokenize(text):
@@ -180,8 +185,208 @@ class HtmlPreprocessorTester(unittest.TestCase):
         ds = Dataset.from_dict(my_dict)
         ds = ds.map(lambda ex: self.html_processor.preprocess(ex), batched=True, batch_size=3)
 
-        self.assertEqual(ds[:]["texts"], target_texts)
+        self.assertEqual(ds[:]["text"], target_texts)
         self.assertEqual(ds[:]["metadata"], target_metadata)
+
+
+class PipelinePreprocessorTester(unittest.TestCase):
+    def setUp(self) -> None:
+        self.create_data()
+
+    def create_data(self):
+        # Define toy data
+        self.init_dict = {
+            "doc_html": [
+                "\n    <html>\n    <head>\n    </head>\n    <body>\n    <h1>This is a title</h1>\n    </body>\n    </html>\n",
+                "<html><body><p>this is a simple paragraph</p></body></html>",
+                "<html><body><p id=1>paragraph 1</p><p id=2>paragraph 2</p></body></html>",
+                '<html><body><div class="div-level-1">blablabla<div class="div-level-2">tidi tidi</div></div></body></html>',
+            ],
+            "url": [
+                "https://www.nytimes.com/1998/03/08/sports/on-pro-basketball-one-last-hurrah-for-the-bulls-reinsdorf-isn-t-quite-saying.html",
+                "https://www.xyz.com",
+                "https://www.test.com",
+                "http://notfound.com",
+            ],
+        }
+
+        # Define target values
+        self.target_texts = [
+            "This is a title\n",
+            "this is a simple paragraph\n",
+            "paragraph 1\nparagraph 2\n",
+            "blablabla\ntidi tidi\n",
+        ]
+
+        self.target_metadata_url = [
+            [
+                {
+                    "key": "url",
+                    "type": "global",
+                    "value": "https://www.nytimes.com/1998/03/08/sports/on-pro-basketball-one-last-hurrah-for-the-bulls-reinsdorf-isn-t-quite-saying.html",
+                },
+            ],
+            [{"key": "url", "type": "global", "value": "https://www.xyz.com"}],
+            [{"key": "url", "type": "global", "value": "https://www.test.com"}],
+            [{"key": "url", "type": "global", "value": "http://notfound.com"}],
+        ]
+
+        self.target_metadata_timestamp = [
+            [
+                {"key": "timestamp", "type": "global", "value": "1998-03-08 00:00:00"},
+            ],
+            [],
+            [],
+            [],
+        ]
+
+        self.target_metadata_website_desc = [
+            [],
+            [
+                {"key": "website_description", "type": "global", "value": "XYZ is a U.S. based company."},
+            ],
+            [{"key": "website_description", "type": "global", "value": "Test is a U.S. based company."}],
+            [],
+        ]
+
+        self.target_metadata_html = [
+            [
+                {
+                    "char_end_idx": 15,
+                    "char_start_idx": 0,
+                    "html_attrs": {"attrs": [], "values": []},
+                    "key": "html",
+                    "relative_end_pos": 0,
+                    "relative_start_pos": 1,
+                    "type": "local",
+                    "value": "h1",
+                },
+                {
+                    "char_end_idx": 16,
+                    "char_start_idx": 0,
+                    "html_attrs": {"attrs": [], "values": []},
+                    "key": "html",
+                    "relative_end_pos": 0,
+                    "relative_start_pos": 0,
+                    "type": "local",
+                    "value": "body",
+                },
+            ],
+            [
+                {
+                    "char_end_idx": 26,
+                    "char_start_idx": 0,
+                    "html_attrs": {"attrs": [], "values": []},
+                    "key": "html",
+                    "relative_end_pos": 0,
+                    "relative_start_pos": 1,
+                    "type": "local",
+                    "value": "p",
+                },
+                {
+                    "char_end_idx": 27,
+                    "char_start_idx": 0,
+                    "html_attrs": {"attrs": [], "values": []},
+                    "key": "html",
+                    "relative_end_pos": 0,
+                    "relative_start_pos": 0,
+                    "type": "local",
+                    "value": "body",
+                },
+            ],
+            [
+                {
+                    "char_end_idx": 11,
+                    "char_start_idx": 0,
+                    "html_attrs": {"attrs": ["id"], "values": ["1"]},
+                    "key": "html",
+                    "relative_end_pos": 0,
+                    "relative_start_pos": 1,
+                    "type": "local",
+                    "value": "p",
+                },
+                {
+                    "char_end_idx": 23,
+                    "char_start_idx": 12,
+                    "html_attrs": {"attrs": ["id"], "values": ["2"]},
+                    "key": "html",
+                    "relative_end_pos": 0,
+                    "relative_start_pos": 0,
+                    "type": "local",
+                    "value": "p",
+                },
+                {
+                    "char_end_idx": 24,
+                    "char_start_idx": 0,
+                    "html_attrs": {"attrs": [], "values": []},
+                    "key": "html",
+                    "relative_end_pos": 0,
+                    "relative_start_pos": 0,
+                    "type": "local",
+                    "value": "body",
+                },
+            ],
+            [
+                {
+                    "char_end_idx": 20,
+                    "char_start_idx": 0,
+                    "html_attrs": {"attrs": ["class"], "values": ["div-level-1 div-level-2"]},
+                    "key": "html",
+                    "relative_end_pos": 0,
+                    "relative_start_pos": 1,
+                    "type": "local",
+                    "value": "div",
+                },
+                {
+                    "char_end_idx": 20,
+                    "char_start_idx": 0,
+                    "html_attrs": {"attrs": [], "values": []},
+                    "key": "html",
+                    "relative_end_pos": 1,
+                    "relative_start_pos": 0,
+                    "type": "local",
+                    "value": "body",
+                },
+            ],
+        ]
+
+    @mock.patch("bsmetadata.preprocessing_tools.wikipedia_desc_utils.DumpDB")
+    @mock.patch("bsmetadata.preprocessing_tools.wikipedia_desc_utils.nltk.sent_tokenize", new=mock_sent_tokenize)
+    def test_toy_dataset(self, mock_db):
+        mock_db.return_value = MockDumpDB("some/path")
+        # Define preprocessors
+        col_to_store_text = "text"
+        col_to_store_metadata_html = "metadata_html"
+        col_to_store_metadata_url = "metadata_url"
+        col_to_store_metadata_timestamp = "metadata_timestamp"
+        col_to_store_metadata_website_desc = "metadata_website_desc"
+
+        html_processor = HtmlPreprocessor(
+            col_to_store_metadata=col_to_store_metadata_html, col_to_store_text=col_to_store_text
+        )
+        url_processor = UrlPreprocessor(col_to_store_metadata=col_to_store_metadata_url, col_url="url")
+        timestamp_processor = TimestampPreprocessor(
+            col_to_store_metadata=col_to_store_metadata_timestamp, col_metadata_url=col_to_store_metadata_url
+        )
+        website_processor = WebsiteDescPreprocessor(
+            col_to_store_metadata=col_to_store_metadata_website_desc, col_metadata_url=col_to_store_metadata_url
+        )
+
+        # Apply function
+        ds = Dataset.from_dict(self.init_dict)
+        ds = ds.map(lambda ex: html_processor.preprocess(ex), batched=True, batch_size=3)
+        ds = ds.map(lambda ex: url_processor.preprocess(ex), batched=True, batch_size=3)
+        ds = ds.map(lambda ex: timestamp_processor.preprocess(ex), batched=True, batch_size=3)
+        ds = ds.map(lambda ex: website_processor.preprocess(ex), batched=True, batch_size=3)
+
+        self.assertEqual(ds[:][col_to_store_text], self.target_texts)
+        self.assertEqual(ds[:][col_to_store_metadata_html], self.target_metadata_html)
+        self.assertEqual(ds[:][col_to_store_metadata_url], self.target_metadata_url)
+        self.assertEqual(ds[:][col_to_store_metadata_timestamp], self.target_metadata_timestamp)
+        self.assertEqual(ds[:][col_to_store_metadata_website_desc], self.target_metadata_website_desc)
+
+        ds.set_format("pandas")
+        print(ds[:])
 
 
 if __name__ == "__main__":

--- a/tests/test_preprocessing_utils.py
+++ b/tests/test_preprocessing_utils.py
@@ -537,7 +537,6 @@ class PipelinePreprocessorTester(unittest.TestCase):
         )
         self.assertEqual(ds[:][col_to_store_metadata_datasource], self.target_metadata_datasource)
 
-
         col_to_store_all_metadata = "metadata"
         columns_names_to_concat = [
             col_to_store_metadata_html,


### PR DESCRIPTION
Here is the beginning of the PR discussed in the meeting. This RP includes:
- the possibility to choose in which column the metadata are extracted
- create the column if it does not exist
- a new `UrlProcessor` to extract the url in the same format as the other metadata
- tests that extract in cascade several types of metadata (in the case 1) where they are extracted in different columns and 2) in the same column): can you all see if the extraction on this toy dataset suits you? :pray: 

Ready for review:
- Timestamp @cccntu 
- Website Desc @shanyas10 
- Entities @manandey (please note that I've addded some mocks to test your entities extraction in our github workflows)
- Datasource & Generation Length @chkla (I've pinged you on some part of the code because I've included some changes I've suggested yesterday)

cc @timoschick (if you can have a more deep review for the `HtmlProcessor` and `UrlProcessor` part it would be of a great help!)