### PR TITLE
bug: fix the toy joint training slurm scripts

### DIFF
--- a/experiments/jz/joint_training_toy/joint_training_toy1/03_create_dataset.slurm
+++ b/experiments/jz/joint_training_toy/joint_training_toy1/03_create_dataset.slurm
@@ -4,7 +4,6 @@
 #SBATCH --ntasks-per-node=1                                            # crucial - only 1 task per dist per node!
 #SBATCH --cpus-per-task=20                                             # (change me! between 0 and 40) number of cores per tasks
 #SBATCH --hint=nomultithread                                           # we get physical cores not logical
-#SBATCH --gres=gpu:0                                                    # (change me! between 0 and 1) number of gpus
 #SBATCH --time 01:00:00                                                # (change me! between 0 and 20h) maximum execution time (HH:MM:SS) 
 #SBATCH --output=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.out  # output file name
 #SBATCH --error=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.err   # error file name


### PR DESCRIPTION
There was a small error that crept into the training scripts, if you put `SBATCH --gres=gpu:1` and `SBATCH --account=six@cpu` together, it creates a SLURM allocation error. This PR proposes to remove the instruction that blocks the job.