### PR TITLE
Add fp16, multi-GPU training script (toy dataset)

### DIFF
--- a/bsmetadata/experiments/with_metadata.py
+++ b/bsmetadata/experiments/with_metadata.py
@@ -11,6 +11,9 @@ from bsmetadata.metadata_utils import add_metadata_and_chunk_examples
 logger = logging.getLogger(__name__)
 
 
+load_dataset = functools.partial(load_dataset, use_auth_token=True)
+
+
 def get_dataloaders(tokenizer, args):
     """
     Args:

--- a/bsmetadata/train.py
+++ b/bsmetadata/train.py
@@ -275,6 +275,7 @@ def main(args: CFG) -> None:
                 optimizer.zero_grad()
                 progress_bar.update(1)
                 completed_steps += 1
+                metrics_logger.log({"gradient_step": completed_steps})
             else:
                 continue
 

--- a/experiments/jz/joint_training_toy/joint_training_toy2-fp16/01_load_tokenizer_and_model.slurm
+++ b/experiments/jz/joint_training_toy/joint_training_toy2-fp16/01_load_tokenizer_and_model.slurm
@@ -1,0 +1,29 @@
+#!/bin/bash
+#SBATCH --job-name=modelling-metadata-joint-toy-1                                # (change me!) job name
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1                                             # crucial - only 1 task per dist per node!
+#SBATCH --cpus-per-task=8                                               # (change me! between 0 and 48) number of cores per tasks
+#SBATCH --hint=nomultithread                                            # we get physical cores not logical
+#SBATCH --gres=gpu:0                                                    # (change me! between 0 and 1) number of gpus
+#SBATCH --time 00:10:00                                                 # (change me! between 0 and 20h) maximum execution time (HH:MM:SS)
+#SBATCH --output=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.out   # output file name
+#SBATCH --error=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.err    # error file name
+#SBATCH --account=six@gpu                                               # account
+#SBATCH -p compil                                                       # partition with internet
+
+set -x -e
+
+# Next line will:
+# - load a conda environment with the dependencies on the master branch of github.com/bigscience-workshop/metadata/
+# - setup env vars ($HOME, $WORK, etc)
+# - load several modules (git)
+# Note: We can afford to have two conda environments: one stable for running experiments and one for development.
+# If there are new dependencies to install, you have to tell me about them and not do it in this script
+source $HOME/start-modelling-metadata-user
+
+# Folder for the clone of github.com/bigscience-workshop/metadata/
+cd $WORK/repos/metadata/
+
+# Command to load the XXX model and tokenizer stored on https://huggingface.co/models
+python experiments/jz/utils/loading_script_utils/load_tokenizer_and_model.py \
+    model_name=gpt2 # (change me! e.g. gpt2)

--- a/experiments/jz/joint_training_toy/joint_training_toy2-fp16/02_load_dataset.slurm
+++ b/experiments/jz/joint_training_toy/joint_training_toy2-fp16/02_load_dataset.slurm
@@ -1,0 +1,63 @@
+#!/bin/bash
+#SBATCH --job-name=modelling-metadata-joint-toy-1
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1                                             # crucial - only 1 task per dist per node!
+#SBATCH --cpus-per-task=8                                               # (change me! between 0 and 48) number of cores per tasks 
+#SBATCH --hint=nomultithread                                            # we get physical cores not logical
+#SBATCH --gres=gpu:0                                                    # (change me! between 0 and 1) number of gpus 
+#SBATCH --time 00:10:00                                                 # (change me! between 0 and 20h) maximum execution time (HH:MM:SS) 
+#SBATCH --output=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.out   # output file name
+#SBATCH --error=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.err    # error file name
+#SBATCH --account=six@gpu                                               # account
+#SBATCH -p compil                                                       # partition with internet
+
+
+set -x -e
+
+# Next line will:
+# - load a conda environment with the dependencies on the master branch of github.com/bigscience-workshop/metadata/
+# - setup env vars ($HOME, $WORK, etc)
+# - load several modules (git)
+# Note: We can afford to have two conda environments: one stable for running experiments and one for development.
+# If there are new dependencies to install, you have to tell me about them and not do it in this script
+source $HOME/start-modelling-metadata-user
+
+# For the moment we can't directly use the new dataset feature on JZ which would avoid having to clone the dataset
+# repo from the HUB. So the first thing to do is to clone the repo of the XXX dataset if it does not already exist.
+HUB_REPO_NAME='bs-modeling-metadata/c4-en-reduced-with-metadata' # (change me! e.g. SaulLu/Natural_Questions_HTML_Toy_v2)
+
+# We define the name of the folder in which the clone will be made
+#Define multi-character delimiter
+delimiter="/"
+#Concatenate the delimiter with the main string
+string=$HUB_REPO_NAME$delimiter
+
+#Split the text based on the delimiter
+myarray=()
+while [[ $string ]]; do
+  myarray+=( "${string%%"$delimiter"*}" )
+  string=${string#*"$delimiter"}
+done
+REPO_DIR="${DATASETS_CUSTOM}/${myarray[-1]}"
+
+# We clone the repo if it doesn't exist
+if [[ -d "${REPO_DIR}" ]]
+then
+    echo "${REPO_DIR} already exists on your filesystem."
+else
+    echo "${REPO_DIR} doesn't exists on your filesystem."
+    cd $DATASETS_CUSTOM/
+    git clone "https://huggingface.co/datasets/${HUB_REPO_NAME}"
+    cd ${REPO_DIR}
+    git lfs install
+    git lfs pull origin master
+fi
+
+cd $WORK/repos/sync/metadata/
+
+# We check that the dataset can indeed be loaded
+python experiments/jz/utils/loading_script_utils/load_dataset.py \
+    dataset_name="${REPO_DIR}" 
+    # \
+    # train_file="XXX" \ # (change me and remove the comment! e.g "nq-train-*.jsonl.gz" or remove arg)
+    # validation_file="XXX" # (change me and remove the comment! e.g. "nq-dev-*.jsonl.gz" or remove arg)

--- a/experiments/jz/joint_training_toy/joint_training_toy2-fp16/03_create_dataset.slurm
+++ b/experiments/jz/joint_training_toy/joint_training_toy2-fp16/03_create_dataset.slurm
@@ -1,0 +1,55 @@
+#!/bin/bash
+#SBATCH --job-name=modelling-metadata-html-joint-toy-1
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1                                            # crucial - only 1 task per dist per node!
+#SBATCH --cpus-per-task=20                                             # (change me! between 0 and 40) number of cores per tasks
+#SBATCH --hint=nomultithread                                           # we get physical cores not logical
+#SBATCH --time 01:00:00                                                # (change me! between 0 and 20h) maximum execution time (HH:MM:SS) 
+#SBATCH --output=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.out  # output file name
+#SBATCH --error=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.err   # error file name
+#SBATCH --account=six@cpu # account
+
+set -x -e
+
+# Next line will:
+# - load a conda environment with the dependencies on the master branch of github.com/bigscience-workshop/metadata/
+# - setup env vars ($HOME, $WORK, etc)
+# - load several modules (git)
+# Note: We can afford to have two conda environments: one stable for running experiments and one for development.
+# If there are new dependencies to install, you have to tell me about them and not do it in this script
+source $HOME/start-modelling-metadata-user
+
+# We are on an offline partition
+export HF_DATASETS_OFFLINE=1
+export TRANSFORMERS_OFFLINE=1
+
+# Folder for the clone of github.com/bigscience-workshop/metadata/
+cd $WORK/repos/metadata/
+
+HUB_REPO_NAME='bs-modeling-metadata/c4-en-reduced-with-metadata' # (change me! e.g. SaulLu/Natural_Questions_HTML_Toy_v2)
+
+# We define the name of the folder in which the clone will be made
+#Define multi-character delimiter
+delimiter="/"
+#Concatenate the delimiter with the main string
+string=$HUB_REPO_NAME$delimiter
+
+#Split the text based on the delimiter
+myarray=()
+while [[ $string ]]; do
+  myarray+=( "${string%%"$delimiter"*}" )
+  string=${string#*"$delimiter"}
+done
+REPO_DIR="${DATASETS_CUSTOM}/${myarray[-1]}"
+
+# Now we launch the script that will perform the preprocessing of the dataset
+# Feel free to add any arguments you like (change me!)
+python bsmetadata/train.py \
+    data_config.experiment="with_metadata" \
+    data_config.metadata_config.metadata_list='[entity, timestamp, url, website_description]' \
+    data_config.metadata_config.max_seq_len=1024 \
+    data_config.dataset_name="${REPO_DIR}" \
+    data_config.preprocessing_num_workers=8 \
+    out_dir="${SCRATCH}/metadata_outputs" \
+    do_train=False \
+    do_eval=False

--- a/experiments/jz/joint_training_toy/joint_training_toy2-fp16/03_create_dataset.slurm
+++ b/experiments/jz/joint_training_toy/joint_training_toy2-fp16/03_create_dataset.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --job-name=modelling-metadata-html-joint-toy-1
+#SBATCH --job-name=modelling-metadata-html-joint_training_toy2-fp16
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1                                            # crucial - only 1 task per dist per node!
 #SBATCH --cpus-per-task=20                                             # (change me! between 0 and 40) number of cores per tasks

--- a/experiments/jz/joint_training_toy/joint_training_toy2-fp16/04_do_training.slurm
+++ b/experiments/jz/joint_training_toy/joint_training_toy2-fp16/04_do_training.slurm
@@ -46,7 +46,19 @@ while [[ $string ]]; do
 done
 REPO_DIR="${DATASETS_CUSTOM}/${myarray[-1]}"
 
-python bsmetadata/train.py \
+echo "compute_environment: LOCAL_MACHINE
+deepspeed_config: {}
+distributed_type: 'NO'
+fp16: true
+machine_rank: 0
+main_process_ip: null
+main_process_port: null
+main_training_function: main
+num_machines: 1
+num_processes: 1
+" > accelerate_config.yaml
+
+accelerate launch --config_file accelerate_config.yaml bsmetadata/train.py \
     data_config.experiment="with_metadata" \
     data_config.metadata_config.metadata_list='[entity, timestamp, url, website_description]' \
     data_config.metadata_config.max_seq_len=1024 \

--- a/experiments/jz/joint_training_toy/joint_training_toy2-fp16/04_do_training.slurm
+++ b/experiments/jz/joint_training_toy/joint_training_toy2-fp16/04_do_training.slurm
@@ -1,0 +1,63 @@
+#!/bin/bash
+#SBATCH --job-name=modelling-metadata-html-joint-toy-1
+#SBATCH --ntasks=1                    # number of MP tasks
+#SBATCH --constraint=v100-16g
+#SBATCH --cpus-per-task=8                                              # (change me! between 0 and 40) number of cores per tasks
+#SBATCH --hint=nomultithread                                           # we get physical cores not logical
+#SBATCH --time 01:00:00                                                # (change me! between 0 and 20h) maximum execution time (HH:MM:SS) 
+#SBATCH --gres=gpu:1                                                    # (change me! between 0 and 1) number of gpus 
+#SBATCH --output=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.out  # output file name
+#SBATCH --error=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.err   # error file name         # error file name
+#SBATCH --account=six@gpu                                              # account
+
+set -x -e
+
+# Next line will:
+# - load a conda environment with the dependencies on the master branch of github.com/bigscience-workshop/metadata/
+# - setup env vars ($HOME, $WORK, etc)
+# - load several modules (git)
+# Note: We can afford to have two conda environments: one stable for running experiments and one for development.
+# If there are new dependencies to install, you have to tell me about them and not do it in this script
+source $HOME/start-modelling-metadata-user
+
+# We are on an offline partition
+export HF_DATASETS_OFFLINE=1
+export TRANSFORMERS_OFFLINE=1
+# be careful about the cache folder for Wandb
+export WANDB_MODE=offline
+export WANDB_DIR=$SCRATCH
+
+# Folder for the clone of github.com/bigscience-workshop/metadata/
+cd $WORK/repos/metadata/
+
+HUB_REPO_NAME='bs-modeling-metadata/c4-en-reduced-with-metadata' # (change me! e.g. SaulLu/Natural_Questions_HTML_Toy_v2)
+
+# We define the name of the folder in which the clone will be made
+#Define multi-character delimiter
+delimiter="/"
+#Concatenate the delimiter with the main string
+string=$HUB_REPO_NAME$delimiter
+
+#Split the text based on the delimiter
+myarray=()
+while [[ $string ]]; do
+  myarray+=( "${string%%"$delimiter"*}" )
+  string=${string#*"$delimiter"}
+done
+REPO_DIR="${DATASETS_CUSTOM}/${myarray[-1]}"
+
+python bsmetadata/train.py \
+    data_config.experiment="with_metadata" \
+    data_config.metadata_config.metadata_list='[entity, timestamp, url, website_description]' \
+    data_config.metadata_config.max_seq_len=1024 \
+    data_config.dataset_name="${REPO_DIR}" \
+    data_config.preprocessing_num_workers=8 \
+    out_dir="${SCRATCH}/metadata_outputs/${SLURM_JOB_ID}" \
+    jobid="${SLURM_JOB_ID}" \
+    do_train=True \
+    do_eval=True \
+    evaluation_strategy=STEPS \
+    eval_steps=50 \
+    save_strategy=STEPS \
+    save_steps=50 \
+    gradient_accumulation_steps=2

--- a/experiments/jz/joint_training_toy/joint_training_toy2-fp16/04_do_training.slurm
+++ b/experiments/jz/joint_training_toy/joint_training_toy2-fp16/04_do_training.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --job-name=modelling-metadata-html-joint-toy-1
+#SBATCH --job-name=modelling-metadata-html-joint_training_toy2-fp16
 #SBATCH --ntasks=1                    # number of MP tasks
 #SBATCH --constraint=v100-16g
 #SBATCH --cpus-per-task=8                                              # (change me! between 0 and 40) number of cores per tasks

--- a/experiments/jz/joint_training_toy/joint_training_toy2-fp16/README.md
+++ b/experiments/jz/joint_training_toy/joint_training_toy2-fp16/README.md
@@ -1,0 +1,10 @@
+# Experiment template
+
+In this folder you will find script templates to run a "typical" experiment on JZ.
+
+These scripts are designed to be run sequentially for:
+
+1. Downloading the tokenizer and the model (`01_load_tokenizer_and_model.slurm`)
+2. Downloading the dataset on a partition with internet ( `02_load_dataset.slurm`)
+3. Preprocessing the dataset on a cpu-only partition (`03_create_dataset.slurm`)
+4. Running the training on a gpu 16gb partition (`04_do_training.slurm`)

--- a/experiments/jz/joint_training_toy/joint_training_toy2-fp16/multi_steps.bash
+++ b/experiments/jz/joint_training_toy/joint_training_toy2-fp16/multi_steps.bash
@@ -1,0 +1,4 @@
+JID_JOB1=$(sbatch 01_load_tokenizer_and_model.slurm | cut -d " " -f 4)
+JID_JOB2=$(sbatch --dependency=afterok:$JID_JOB1 02_load_dataset.slurm | cut -d " " -f 4)
+JID_JOB3=$(sbatch --dependency=afterok:$JID_JOB2 03_create_dataset.slurm | cut -d " " -f 4)
+sbatch --dependency=afterok:$JID_JOB3 04_do_training.slurm

--- a/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/01_load_tokenizer_and_model.slurm
+++ b/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/01_load_tokenizer_and_model.slurm
@@ -1,0 +1,29 @@
+#!/bin/bash
+#SBATCH --job-name=modelling-metadata-joint-toy-1                                # (change me!) job name
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1                                             # crucial - only 1 task per dist per node!
+#SBATCH --cpus-per-task=8                                               # (change me! between 0 and 48) number of cores per tasks
+#SBATCH --hint=nomultithread                                            # we get physical cores not logical
+#SBATCH --gres=gpu:0                                                    # (change me! between 0 and 1) number of gpus
+#SBATCH --time 00:10:00                                                 # (change me! between 0 and 20h) maximum execution time (HH:MM:SS)
+#SBATCH --output=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.out   # output file name
+#SBATCH --error=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.err    # error file name
+#SBATCH --account=six@gpu                                               # account
+#SBATCH -p compil                                                       # partition with internet
+
+set -x -e
+
+# Next line will:
+# - load a conda environment with the dependencies on the master branch of github.com/bigscience-workshop/metadata/
+# - setup env vars ($HOME, $WORK, etc)
+# - load several modules (git)
+# Note: We can afford to have two conda environments: one stable for running experiments and one for development.
+# If there are new dependencies to install, you have to tell me about them and not do it in this script
+source $HOME/start-modelling-metadata-user
+
+# Folder for the clone of github.com/bigscience-workshop/metadata/
+cd $WORK/repos/metadata/
+
+# Command to load the XXX model and tokenizer stored on https://huggingface.co/models
+python experiments/jz/utils/loading_script_utils/load_tokenizer_and_model.py \
+    model_name=gpt2 # (change me! e.g. gpt2)

--- a/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/02_load_dataset.slurm
+++ b/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/02_load_dataset.slurm
@@ -1,0 +1,63 @@
+#!/bin/bash
+#SBATCH --job-name=modelling-metadata-joint-toy-1
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1                                             # crucial - only 1 task per dist per node!
+#SBATCH --cpus-per-task=8                                               # (change me! between 0 and 48) number of cores per tasks 
+#SBATCH --hint=nomultithread                                            # we get physical cores not logical
+#SBATCH --gres=gpu:0                                                    # (change me! between 0 and 1) number of gpus 
+#SBATCH --time 00:10:00                                                 # (change me! between 0 and 20h) maximum execution time (HH:MM:SS) 
+#SBATCH --output=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.out   # output file name
+#SBATCH --error=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.err    # error file name
+#SBATCH --account=six@gpu                                               # account
+#SBATCH -p compil                                                       # partition with internet
+
+
+set -x -e
+
+# Next line will:
+# - load a conda environment with the dependencies on the master branch of github.com/bigscience-workshop/metadata/
+# - setup env vars ($HOME, $WORK, etc)
+# - load several modules (git)
+# Note: We can afford to have two conda environments: one stable for running experiments and one for development.
+# If there are new dependencies to install, you have to tell me about them and not do it in this script
+source $HOME/start-modelling-metadata-user
+
+# For the moment we can't directly use the new dataset feature on JZ which would avoid having to clone the dataset
+# repo from the HUB. So the first thing to do is to clone the repo of the XXX dataset if it does not already exist.
+HUB_REPO_NAME='bs-modeling-metadata/c4-en-reduced-with-metadata' # (change me! e.g. SaulLu/Natural_Questions_HTML_Toy_v2)
+
+# We define the name of the folder in which the clone will be made
+#Define multi-character delimiter
+delimiter="/"
+#Concatenate the delimiter with the main string
+string=$HUB_REPO_NAME$delimiter
+
+#Split the text based on the delimiter
+myarray=()
+while [[ $string ]]; do
+  myarray+=( "${string%%"$delimiter"*}" )
+  string=${string#*"$delimiter"}
+done
+REPO_DIR="${DATASETS_CUSTOM}/${myarray[-1]}"
+
+# We clone the repo if it doesn't exist
+if [[ -d "${REPO_DIR}" ]]
+then
+    echo "${REPO_DIR} already exists on your filesystem."
+else
+    echo "${REPO_DIR} doesn't exists on your filesystem."
+    cd $DATASETS_CUSTOM/
+    git clone "https://huggingface.co/datasets/${HUB_REPO_NAME}"
+    cd ${REPO_DIR}
+    git lfs install
+    git lfs pull origin master
+fi
+
+cd $WORK/repos/sync/metadata/
+
+# We check that the dataset can indeed be loaded
+python experiments/jz/utils/loading_script_utils/load_dataset.py \
+    dataset_name="${REPO_DIR}" 
+    # \
+    # train_file="XXX" \ # (change me and remove the comment! e.g "nq-train-*.jsonl.gz" or remove arg)
+    # validation_file="XXX" # (change me and remove the comment! e.g. "nq-dev-*.jsonl.gz" or remove arg)

--- a/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/03_create_dataset.slurm
+++ b/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/03_create_dataset.slurm
@@ -1,0 +1,55 @@
+#!/bin/bash
+#SBATCH --job-name=modelling-metadata-html-joint-toy-1
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1                                            # crucial - only 1 task per dist per node!
+#SBATCH --cpus-per-task=20                                             # (change me! between 0 and 40) number of cores per tasks
+#SBATCH --hint=nomultithread                                           # we get physical cores not logical
+#SBATCH --time 01:00:00                                                # (change me! between 0 and 20h) maximum execution time (HH:MM:SS) 
+#SBATCH --output=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.out  # output file name
+#SBATCH --error=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.err   # error file name
+#SBATCH --account=six@cpu # account
+
+set -x -e
+
+# Next line will:
+# - load a conda environment with the dependencies on the master branch of github.com/bigscience-workshop/metadata/
+# - setup env vars ($HOME, $WORK, etc)
+# - load several modules (git)
+# Note: We can afford to have two conda environments: one stable for running experiments and one for development.
+# If there are new dependencies to install, you have to tell me about them and not do it in this script
+source $HOME/start-modelling-metadata-user
+
+# We are on an offline partition
+export HF_DATASETS_OFFLINE=1
+export TRANSFORMERS_OFFLINE=1
+
+# Folder for the clone of github.com/bigscience-workshop/metadata/
+cd $WORK/repos/metadata/
+
+HUB_REPO_NAME='bs-modeling-metadata/c4-en-reduced-with-metadata' # (change me! e.g. SaulLu/Natural_Questions_HTML_Toy_v2)
+
+# We define the name of the folder in which the clone will be made
+#Define multi-character delimiter
+delimiter="/"
+#Concatenate the delimiter with the main string
+string=$HUB_REPO_NAME$delimiter
+
+#Split the text based on the delimiter
+myarray=()
+while [[ $string ]]; do
+  myarray+=( "${string%%"$delimiter"*}" )
+  string=${string#*"$delimiter"}
+done
+REPO_DIR="${DATASETS_CUSTOM}/${myarray[-1]}"
+
+# Now we launch the script that will perform the preprocessing of the dataset
+# Feel free to add any arguments you like (change me!)
+python bsmetadata/train.py \
+    data_config.experiment="with_metadata" \
+    data_config.metadata_config.metadata_list='[entity, timestamp, url, website_description]' \
+    data_config.metadata_config.max_seq_len=1024 \
+    data_config.dataset_name="${REPO_DIR}" \
+    data_config.preprocessing_num_workers=8 \
+    out_dir="${SCRATCH}/metadata_outputs" \
+    do_train=False \
+    do_eval=False

--- a/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/03_create_dataset.slurm
+++ b/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/03_create_dataset.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --job-name=modelling-metadata-html-joint-toy-1
+#SBATCH --job-name=modelling-metadata-html-joint_training_toy3-fp16-multigpu
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1                                            # crucial - only 1 task per dist per node!
 #SBATCH --cpus-per-task=20                                             # (change me! between 0 and 40) number of cores per tasks

--- a/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/04_do_training.slurm
+++ b/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/04_do_training.slurm
@@ -1,0 +1,75 @@
+#!/bin/bash
+#SBATCH --job-name=modelling-metadata-html-joint-toy-1
+#SBATCH --ntasks=1                    # number of MP tasks
+#SBATCH --constraint=v100-16g
+#SBATCH --cpus-per-task=8                                              # (change me! between 0 and 40) number of cores per tasks
+#SBATCH --hint=nomultithread                                           # we get physical cores not logical
+#SBATCH --time 01:00:00                                                # (change me! between 0 and 20h) maximum execution time (HH:MM:SS) 
+#SBATCH --gres=gpu:1                                                    # (change me! between 0 and 1) number of gpus 
+#SBATCH --output=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.out  # output file name
+#SBATCH --error=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.err   # error file name         # error file name
+#SBATCH --account=six@gpu                                              # account
+
+set -x -e
+
+# Next line will:
+# - load a conda environment with the dependencies on the master branch of github.com/bigscience-workshop/metadata/
+# - setup env vars ($HOME, $WORK, etc)
+# - load several modules (git)
+# Note: We can afford to have two conda environments: one stable for running experiments and one for development.
+# If there are new dependencies to install, you have to tell me about them and not do it in this script
+source $HOME/start-modelling-metadata-user
+
+# We are on an offline partition
+export HF_DATASETS_OFFLINE=1
+export TRANSFORMERS_OFFLINE=1
+# be careful about the cache folder for Wandb
+export WANDB_MODE=offline
+export WANDB_DIR=$SCRATCH
+
+# Folder for the clone of github.com/bigscience-workshop/metadata/
+cd $WORK/repos/metadata/
+
+HUB_REPO_NAME='bs-modeling-metadata/c4-en-reduced-with-metadata' # (change me! e.g. SaulLu/Natural_Questions_HTML_Toy_v2)
+
+# We define the name of the folder in which the clone will be made
+#Define multi-character delimiter
+delimiter="/"
+#Concatenate the delimiter with the main string
+string=$HUB_REPO_NAME$delimiter
+
+#Split the text based on the delimiter
+myarray=()
+while [[ $string ]]; do
+  myarray+=( "${string%%"$delimiter"*}" )
+  string=${string#*"$delimiter"}
+done
+REPO_DIR="${DATASETS_CUSTOM}/${myarray[-1]}"
+
+echo "compute_environment: LOCAL_MACHINE
+deepspeed_config: {}
+distributed_type: 'NO'
+fp16: true
+machine_rank: 0
+main_process_ip: null
+main_process_port: null
+main_training_function: main
+num_machines: 1
+num_processes: 1
+" > accelerate_config.yaml
+
+accelerate launch --config_file accelerate_config.yaml bsmetadata/train.py \
+    data_config.experiment="with_metadata" \
+    data_config.metadata_config.metadata_list='[entity, timestamp, url, website_description]' \
+    data_config.metadata_config.max_seq_len=1024 \
+    data_config.dataset_name="${REPO_DIR}" \
+    data_config.preprocessing_num_workers=8 \
+    out_dir="${SCRATCH}/metadata_outputs/${SLURM_JOB_ID}" \
+    jobid="${SLURM_JOB_ID}" \
+    do_train=True \
+    do_eval=True \
+    evaluation_strategy=STEPS \
+    eval_steps=50 \
+    save_strategy=STEPS \
+    save_steps=50 \
+    gradient_accumulation_steps=2

--- a/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/04_do_training.slurm
+++ b/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/04_do_training.slurm
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --job-name=modelling-metadata-html-joint-toy-1
+#SBATCH --job-name=modelling-metadata-html-joint_training_toy3-fp16-multigpu
 #SBATCH --ntasks=1                    # number of MP tasks
 #SBATCH --constraint=v100-16g
 #SBATCH --cpus-per-task=8                                              # (change me! between 0 and 40) number of cores per tasks

--- a/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/04_do_training.slurm
+++ b/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/04_do_training.slurm
@@ -5,7 +5,7 @@
 #SBATCH --cpus-per-task=8                                              # (change me! between 0 and 40) number of cores per tasks
 #SBATCH --hint=nomultithread                                           # we get physical cores not logical
 #SBATCH --time 01:00:00                                                # (change me! between 0 and 20h) maximum execution time (HH:MM:SS) 
-#SBATCH --gres=gpu:1                                                    # (change me! between 0 and 1) number of gpus 
+#SBATCH --gres=gpu:2                                                    # (change me! between 0 and 1) number of gpus
 #SBATCH --output=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.out  # output file name
 #SBATCH --error=/gpfsdswork/projects/rech/six/uue59kq/logs/%x-%j.err   # error file name         # error file name
 #SBATCH --account=six@gpu                                              # account
@@ -55,7 +55,7 @@ main_process_ip: null
 main_process_port: null
 main_training_function: main
 num_machines: 1
-num_processes: 1
+num_processes: 2
 " > accelerate_config.yaml
 
 accelerate launch --config_file accelerate_config.yaml bsmetadata/train.py \

--- a/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/README.md
+++ b/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/README.md
@@ -1,0 +1,10 @@
+# Experiment template
+
+In this folder you will find script templates to run a "typical" experiment on JZ.
+
+These scripts are designed to be run sequentially for:
+
+1. Downloading the tokenizer and the model (`01_load_tokenizer_and_model.slurm`)
+2. Downloading the dataset on a partition with internet ( `02_load_dataset.slurm`)
+3. Preprocessing the dataset on a cpu-only partition (`03_create_dataset.slurm`)
+4. Running the training on a gpu 16gb partition (`04_do_training.slurm`)

--- a/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/local_test.sh
+++ b/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/local_test.sh
@@ -1,0 +1,26 @@
+echo "compute_environment: LOCAL_MACHINE
+deepspeed_config: {}
+distributed_type: 'NO'
+fp16: true
+machine_rank: 0
+main_process_ip: null
+main_process_port: null
+main_training_function: main
+num_machines: 1
+num_processes: 2
+" > accelerate_config.yaml
+
+accelerate launch --config_file accelerate_config.yaml bsmetadata/train.py \
+    data_config.experiment="with_metadata" \
+    data_config.metadata_config.metadata_list='[entity, timestamp, url, website_description]' \
+    data_config.metadata_config.max_seq_len=1024 \
+    data_config.dataset_name=bs-modeling-metadata/c4-en-reduced-with-metadata \
+    data_config.preprocessing_num_workers=8 \
+    out_dir="metadata_outputs/${SLURM_JOB_ID}" \
+    jobid="${SLURM_JOB_ID}" \
+    do_train=True \
+    do_eval=True \
+    evaluation_strategy=STEPS \
+    eval_steps=50 \
+    save_strategy=STEPS \
+    save_steps=51 \

--- a/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/multi_steps.bash
+++ b/experiments/jz/joint_training_toy/joint_training_toy3-fp16-multigpu/multi_steps.bash
@@ -1,0 +1,4 @@
+JID_JOB1=$(sbatch 01_load_tokenizer_and_model.slurm | cut -d " " -f 4)
+JID_JOB2=$(sbatch --dependency=afterok:$JID_JOB1 02_load_dataset.slurm | cut -d " " -f 4)
+JID_JOB3=$(sbatch --dependency=afterok:$JID_JOB2 03_create_dataset.slurm | cut -d " " -f 4)
+sbatch --dependency=afterok:$JID_JOB3 04_do_training.slurm


### PR DESCRIPTION

* Changed an argument in load_dataset so it tries to read private datasets.
* Added gradient_step logging, so we can see time v.s. gradient step on wandb

* Adds 2 sub-experiments
  1.  + fp16
  2.  + fp16, 2 GPU
     * note: I only have 1 GPU, so I couldn't test this one, but I included a `local_test.sh` that can be used to test.

* The toy dataset used is now privated. To run the experiments, you'd need to configure the huggingface access tokens with `huggingface-cli  login`.
