### PR TITLE
Filter examples by `num_chars` to include in a batch

### DIFF
--- a/bsmetadata/preprocessing_utils.py
+++ b/bsmetadata/preprocessing_utils.py
@@ -302,7 +302,7 @@ class EntityPreprocessor(
     def __init__(
         self,
         base_url,
-        num_chars,
+        num_chars=4000, #default length of text set as threshold to include an example in a batch
         path_or_url_flair_ner_model="ner-fast",
         col_to_store_metadata="metadata",
         col_text="text",
@@ -336,7 +336,7 @@ class EntityPreprocessor(
         return features
 
     def preprocess_example(self, examples: Dict[str, List]) -> Dict[str, List]:
-        # preprocess all the examples in a particular batch in the required format and consider an example only if length of text is less or equal to num_chars
+        # preprocess all the examples in a particular batch in the required format and consider an example only if length of text is less than or equal to num_chars
         processed = {ex_id: [ex_text, []] for ex_id, ex_text in enumerate(examples[self.col_text]) if len(ex_text) <= self.num_chars}
         return processed
 

--- a/bsmetadata/preprocessing_utils.py
+++ b/bsmetadata/preprocessing_utils.py
@@ -336,7 +336,7 @@ class EntityPreprocessor(
         return features
 
     def preprocess_example(self, examples: Dict[str, List]) -> Dict[str, List]:
-        # preprocess all the examples in a particular batch in the required format and check if length of text is less than num_chars
+        # preprocess all the examples in a particular batch in the required format and consider an example only if length of text is less or equal to num_chars
         processed = {ex_id: [ex_text, []] for ex_id, ex_text in enumerate(examples[self.col_text]) if len(ex_text) <= self.num_chars}
         return processed
 

--- a/bsmetadata/preprocessing_utils.py
+++ b/bsmetadata/preprocessing_utils.py
@@ -302,7 +302,7 @@ class EntityPreprocessor(
     def __init__(
         self,
         base_url,
-        num_chars=4000, #default length of text set as threshold to include an example in a batch
+        num_chars=5000, #default length of text set as threshold to include an example in a batch
         path_or_url_flair_ner_model="ner-fast",
         col_to_store_metadata="metadata",
         col_text="text",

--- a/bsmetadata/preprocessing_utils.py
+++ b/bsmetadata/preprocessing_utils.py
@@ -302,6 +302,7 @@ class EntityPreprocessor(
     def __init__(
         self,
         base_url,
+        num_chars,
         path_or_url_flair_ner_model="ner-fast",
         col_to_store_metadata="metadata",
         col_text="text",
@@ -315,7 +316,7 @@ class EntityPreprocessor(
             "model_path": "ed-wiki-2019",
         }
         self.model = EntityDisambiguation(self.base_url, self.wiki_version, self.config, reset_embeddings=True)
-
+        self.num_chars = num_chars
         self.col_text = col_text
         super().__init__(col_to_store_metadata=col_to_store_metadata)
 
@@ -335,8 +336,8 @@ class EntityPreprocessor(
         return features
 
     def preprocess_example(self, examples: Dict[str, List]) -> Dict[str, List]:
-        # preprocess all the examples in a particular batch in the required format
-        processed = {ex_id: [ex_text, []] for ex_id, ex_text in enumerate(examples[self.col_text])}
+        # preprocess all the examples in a particular batch in the required format and check if length of text is less than num_chars
+        processed = {ex_id: [ex_text, []] for ex_id, ex_text in enumerate(examples[self.col_text]) if len(ex_text) <= self.num_chars}
         return processed
 
     def fetch_mention_predictions(self, examples: Dict[str, List]) -> Dict[str, List]:

--- a/bsmetadata/preprocessing_utils.py
+++ b/bsmetadata/preprocessing_utils.py
@@ -302,7 +302,7 @@ class EntityPreprocessor(
     def __init__(
         self,
         base_url,
-        num_chars=5000, #default length of text set as threshold to include an example in a batch
+        num_chars=5000,  # default length of text set as threshold to include an example in a batch
         path_or_url_flair_ner_model="ner-fast",
         col_to_store_metadata="metadata",
         col_text="text",
@@ -337,7 +337,11 @@ class EntityPreprocessor(
 
     def preprocess_example(self, examples: Dict[str, List]) -> Dict[str, List]:
         # preprocess all the examples in a particular batch in the required format and consider an example only if length of text is less than or equal to num_chars
-        processed = {ex_id: [ex_text, []] for ex_id, ex_text in enumerate(examples[self.col_text]) if len(ex_text) <= self.num_chars}
+        processed = {
+            ex_id: [ex_text, []]
+            for ex_id, ex_text in enumerate(examples[self.col_text])
+            if len(ex_text) <= self.num_chars
+        }
         return processed
 
     def fetch_mention_predictions(self, examples: Dict[str, List]) -> Dict[str, List]:


### PR DESCRIPTION
Hi @SaulLu, 

I have updated the `EntityPreprocessor` to include an example in a batch only if its length is less than or equal to `num_chars`. I have set the default value to 5000 characters. Feel free to set a different value. Thanks!

