### PR TITLE
ci: pin Python, Ubuntu, & GH Action versions

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -13,13 +13,13 @@ on:
 jobs:
     check_code_quality:
         name: Check code quality
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
-            - uses: actions/checkout@v2
-            - name: Set up Python 3.7.11
-              uses: actions/setup-python@v2
+            - uses: actions/checkout@v3
+            - name: Set up Python 3.7.15
+              uses: actions/setup-python@v4
               with:
-                  python-version: 3.7.11
+                  python-version: 3.7.15
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,13 @@ on:
 jobs:
     test:
         name: Test
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
-            - uses: actions/checkout@v2
-            - name: Set up Python 3.7.11
-              uses: actions/setup-python@v2
+            - uses: actions/checkout@v3
+            - name: Set up Python 3.7.15
+              uses: actions/setup-python@v4
               with:
-                  python-version: 3.7.11
+                  python-version: 3.7.15
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip


### PR DESCRIPTION
Due to the GH change of "ubuntu-latest," which is 22.04, not 20.04 anymore, and 22.04 doesn't have Python 3.7.11. Therefore, I pin them to the latest versions along with GH action versions.