### PR TITLE
Add loss plotting

### DIFF
--- a/bsmetadata/plot_losses.py
+++ b/bsmetadata/plot_losses.py
@@ -1,0 +1,34 @@
+import argparse
+
+import torch
+from transformers import AutoTokenizer
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--idx",
+        type=int,
+        default=12,
+        help="Index of the loss to plot",
+    )
+    args = parser.parse_args()
+
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+
+    # Load the losses
+    input_ids_meta = torch.load(f"{args.idx}_input_ids_meta.pt") # [batch_size, seq_len]
+    input_ids = torch.load(f"{args.idx}_input_ids.pt") # [batch_size, seq_len]
+
+    loss_meta = torch.load(f"{args.idx}_loss_meta.pt") # [batch_size, seq_len]
+    loss = torch.load(f"{args.idx}_loss.pt") # [batch_size, seq_len]
+
+    # Print the losses
+    print("Meta")
+    tok_losses = [(tokenizer.decode(input_ids_meta[..., i]), round(loss_meta[..., i].item(), 2)) for i in range(input_ids_meta.shape[-1]-1)]
+    print(tok_losses)
+
+    print("Normal")
+    tok_losses = [(tokenizer.decode(input_ids[..., i]), round(loss[..., i].item(), 2)) for i in range(input_ids.shape[-1]-1)]
+    print(tok_losses)
+
+


### PR DESCRIPTION
Example:
```
Meta
[('html', 9.2), (' ||', 5.62), ('|', 5.3), ('<', 3.03), ('div', 2.33), (' id', 8.1), (':', 5.23), ('content', 10.28), (' body', 8.08), ('Content', 6.66), (' class', 0.74), (':', 5.57), ('m', 3.76), ('w', 0.56), ('-', 4.58), ('body', 6.57), (' m', 0.03), ('w', 0.12), ('-', 2.72), ('body', 1.14), ('-', 3.66), ('content', 4.03), ('><', 2.86), ('h', 0.95), ('1', 0.58), ('>', 6.97), ('Media', 4.35), ('Wiki', 6.57), (' 1', 0.17), ('.', 7.35), ('30', 2.5), ('.', 1.34), ('0', 11.42), (' installation', 0.89), ('</', 0.0), ('h', 0.0), ('1', 0.85), ('>', 2.75), ('\n', 10.94), ('<', 1.59), ('div', 0.5), (' class', 0.54), (':', 8.27), ('config', 1.08), ('-', 3.54), ('page', 0.9), ('-', 4.53), ('wrapper', 2.67), ('><', 1.79), ('div', 0.18), (' class', 0.26), (':', 2.22), ('config', 0.05), ('-', 0.19), ('page', 6.59), ('><', 1.34), ('div', 0.16), (' class', 0.01), (':', 0.57), ('config', 0.01), ('-', 0.12), ('page', 0.55), ('-', 6.64), ('list', 2.84), ('><', 4.65), ('ul', 2.29), ('><', 0.05), ('li', 0.86), (' class', 1.09), (':', 2.28), ('config', 0.03), ('-', 0.37), ('page', 0.17), ('-', 2.26), ('list', 1.26), ('-', 2.06), ('item', 3.11), ('>', 8.78), ('Language', 1.07), ('</', 0.0), ('li', 0.69), ('>', 2.0), ('\n', 0.78), ('<', 0.1), ('li', 0.35), (' class', 0.0), (':', 0.11), ('config', 0.0), ('-', 0.01), ('page', 0.0), ('-', 0.08), ('list', 0.02), ('-', 0.02), ('item', 2.14), ('><', 3.01), ('span', 0.33), (' class', 0.05), (':', 0.26), ('config', 0.0), ('-', 0.02), ('page', 0.08), ('-', 8.65), ('disabled', 1.66), ('>', 6.83), ('Ex', 1.17), ('isting', 6.13), (' wiki', 1.01), ('</', 0.0), ('span', 0.69), ('></', 0.12), ('li', 0.35), ('>', 0.15), ('\n', 0.24), ('<', 0.05), ('li', 0.06), (' class', 0.0), (':', 0.01), ('config', 0.0), ('-', 0.0), ('page', 0.0), ('-', 0.1), ('list', 0.0), ('-', 0.01), ('item', 0.2), ('><', 0.28), ('span', 0.03), (' class', 0.0), (':', 0.01), ('config', 0.0), ('-', 0.01), ('page', 0.0), ('-', 0.21), ('disabled', 0.18), ('>', 6.97), ('Welcome', 0.41), (' to', 2.77), (' Media', 0.02), ('Wiki', 3.07), ('!', 0.12), ('</', 0.0), ('span', 0.03), ('></', 0.0), ('li', 0.05), ('>', 0.15), ('\n', 0.39), ('<', 0.03), ('li', 0.03), (' class', 0.0), (':', 0.01), ('config', 0.0), ('-', 0.0), ('page', 0.0), ('-', 0.02), ('list', 0.0), ('-', 0.0), ('item', 0.12), ('><', 0.03), ('span', 0.0), (' class', 0.0), (':', 0.0), ('config', 0.0), ('-', 0.0), ('page', 0.0), ('-', 0.02), ('disabled', 0.02), ('>', 8.32), ('Connect', 1.13), (' to', 8.23), (' database', 0.93), ('</', 0.0), ('span', 0.03), ('></', 0.0), ('li', 0.01), ('>', 0.09), ('\n', 0.29), ('<', 0.02), ('li', 0.0), (' class', 0.0), (':', 0.01), ('config', 0.0), ('-', 0.0), ('page', 0.0), ('-', 0.01), ('list', 0.0), ('-', 0.0), ('item', 0.08), ('><', 0.01), ('span', 0.0), (' class', 0.0), (':', 0.0), ('config', 0.0), ('-', 0.0), ('page', 0.0), ('-', 0.01), ('disabled', 0.02), ('>', 7.65), ('Upgrade', 6.59), (' existing', 6.1), (' installation', 0.31), ('</', 0.0), ('span', 0.01), ('></', 0.0), ('li', 0.0), ('>', 0.08), ('\n', 0.32), ('<', 0.01), ('li', 0.0), (' class', 0.0), (':', 0.01), ('config', 0.0), ('-', 0.0), ('page', 0.0), ('-', 0.01), ('list', 0.0), ('-', 0.0), ('item', 0.08), ('><', 0.0), ('span', 0.0), (' class', 0.0), (':', 0.0), ('config', 0.0), ('-', 0.0), ('page', 0.0), ('-', 0.01), ('disabled', 0.01), ('>', 6.05), ('Database', 6.01), (' settings', 0.22), ('</', 0.0), ('span', 0.01), ('></', 0.0), ('li', 0.0), ('>', 0.06), ('\n', 0.23), ('<', 0.01), ('li', 0.0), (' class', 0.0), (':', 0.01), ('config', 0.0), ('-', 0.0), ('page', 0.0), ('-', 0.0), ('list', 0.0), ('-', 0.0), ('item', 0.06), ('><', 0.0), ('span', 0.0), (' class', 0.0), (':', 0.0), ('config', 0.0), ('-', 0.0), ('page', 0.0), ('-', 0.01), ('disabled', 0.01), ('>', 6.01), ('Name', 0.64), ('</', 0.0), ('span', 0.02), ('></', 0.0), ('li', 0.0), ('>', 0.05), ('\n', 0.2), ('<', 0.01), ('li', 0.0), (' class', 0.0), (':', 0.0), ('config', 0.0), ('-', 0.0), ('page', 0.0), ('-', 0.0), ('list', 0.0), ('-', 0.0), ('item', 0.04), ('><', 0.0), ('span', 0.0), (' class', 0.0), (':', 0.0), ('config', 0.0), ('-', 0.0), ('page', 0.0), ('-', 0.0), ('disabled', 0.01), ('>', 6.79), ('Options', 0.34), ('</', 0.0), ('span', 0.01), ('></', 0.0), ('li', 0.0), ('>', 0.04), ('\n', 0.23), ('<', 0.01), ('li', 0.0), (' class', 0.0), (':', 0.01), ('config', 0.0), ('-', 0.0), ('page', 0.0), ('-', 0.0), ('list', 0.0), ('-', 0.0), ('item', 0.06), ('><', 0.0), ('span', 0.0), (' class', 0.0), (':', 0.0), ('config', 0.0), ('-', 0.0), ('page', 0.0), ('-', 0.01), ('disabled', 0.01), ('>', 5.38), ('Install', 1.92), ('</', 0.0), ('span', 0.01), ('></', 0.0), ('li', 0.0), ('>', 0.04), ('\n', 0.29), ('<', 0.01), ('li', 0.0), (' class', 0.0), (':', 0.01), ('config', 0.0), ('-', 0.0), ('page', 0.0), ('-', 0.0), ('list', 0.0), ('-', 0.0), ('item', 0.04), ('><', 0.0), ('span', 0.0), (' class', 0.0), (':', 0.0), ('config', 0.0), ('-', 0.0), ('page', 0.0), ('-', 0.01), ('disabled', 0.01), ('>', 9.11), ('Complete', 6.38), ('!', 0.1), ('</', 0.0), ('span', 0.02), ('></', 0.0), ('li', 0.0), ('>', 0.08), ('\n', 1.64), ('</', 0.85), ('ul', 0.38), ('>', 0.32), ('\n', 1.75), ('</', 0.15), ('div', 2.81), ('><', 4.54), ('h', 1.24), ('2', 0.35), ('>', 7.28), ('Read', 6.3), (' me', 3.58), ('</', 0.0), ('h', 0.0), ('2', 0.58), ('>', 0.23), ('\n', 0.67), ('<', 2.38), ('h', 0.28), ('2', 2.83), ('><', 1.66), ('span', 0.18), (' class', 0.09), (':', 4.12), ('m', 0.02), ('w', 0.04), ('-', 5.72), ('head', 0.95), ('line', 5.06), (' id', 0.55), (':', 10.62), ('Media', 0.07), ('Wiki', 4.14), ('>', 3.39), ('Media', 0.02), ('Wiki', 3.44), ('</', 0.02), ('span', 0.4), ('></', 0.12), ('h', 0.0), ('2', 0.52), ('>', 0.23), ('\n', 0.18), ('<', 3.49), ('p', 0.68), ('>', 3.07), ('Media', 0.01), ('Wiki', 0.7), (' is', 0.9), (' a', 2.56), (' free', 1.99), (' and', 0.03), (' open', 2.18), ('-', 0.01), ('source', 2.08), (' wiki', 3.22), (' software', 4.62), (' package', 3.75), (' written', 0.31), (' in', 2.89), (' PHP', 1.01), ('.', 0.89), (' It', 6.36), (' serves', 0.32), (' as', 1.55), (' the', 6.07), (' platform', 0.29), (' for', 5.89), (' Wikipedia', 2.29), (' and', 2.8), (' the', 3.43), (' other', 2.71), (' Wikimedia', 1.79), (' projects', 2.47), (',', 6.87), (' used', 1.12), (' by', 4.21), (' hundreds', 0.03), (' of', 1.88), (' millions', 0.15), (' of', 0.53), (' people', 4.36), (' each', 2.26), (' month', 0.41), ('.', 3.32), (' Media', 0.04), ('Wiki', 0.73), (' is', 10.7), (' local', 3.07), ('ised', 3.17), (' in', 6.42), (' over', 5.11), (' 350', 2.02), (' languages', 1.58), (' and', 4.3), (' its', 9.89), (' reliability', 1.47), (' and', 5.21), (' robust', 8.58), (' feature', 0.21), (' set', 4.33), (' have', 4.17), (' earned', 0.27), (' it', 1.21), (' a', 4.81), (' large', 3.78), (' and', 5.32), (' vibrant', 0.54), (' community', 1.57), (' of', 10.12), (' third', 0.71), ('-', 0.06), ('party', 1.43), (' users', 2.44), (' and', 2.24), (' developers', 0.33), ('.', 2.19), ('\n', 5.63), ('</', 0.01), ('p', 2.03), ('><', 2.54), ('ul', 1.11), ('><', 0.05), ('li', 2.13), ('>', 10.63), ('feature', 2.55), ('-', 4.21), ('rich', 4.38), (' and', 5.98), (' ext', 0.01), ('ensible', 3.58), (',', 6.17), (' both', 3.74), (' on', 1.97), ('-', 5.19), ('wiki', 0.23), (' and', 6.24), (' with', 9.17), (' hundreds', 0.02), (' of', 4.18), (' extensions', 6.24), (';', 2.03), ('</', 0.0), ('li', 0.41), ('>', 1.29), ('\n', 0.72), ('<', 0.05), ('li', 0.24), ('>', 7.6), ('sc', 2.86), ('al', 0.39), ('able', 2.69), (' and', 8.79), (' suitable', 0.5), (' for', 3.46), (' both', 4.68), (' small', 0.52), (' and', 0.22), (' large', 3.37), (' sites', 1.02), (';', 0.03), ('</', 0.0), ('li', 0.03), ('>', 0.28), ('\n', 0.3), ('<', 0.0), ('li', 0.05), ('>', 5.49), ('simple', 2.45), (' to', 3.41), (' install', 1.26), (',', 6.99), (' working', 1.78), (' on', 3.77), (' most', 6.91), (' hardware', 5.07), ('/', 0.5), ('software', 4.57), (' combinations', 0.58), (';', 5.9), (' and', 0.02), ('</', 0.0), ('li', 0.0), ('>', 0.44), ('\n', 0.32), ('<', 0.0), ('li', 0.04), ('>', 4.52), ('available', 2.06), (' in', 6.4), (' your', 2.21), (' language', 3.55), ('.</', 0.0), ('li', 0.08), ('>', 0.13), ('\n', 0.59), ('</', 0.1), ('ul', 2.19), ('><', 2.04), ('p', 0.27), ('>', 3.91), ('For', 8.26), (' system', 1.74), (' requirements', 1.0), (',', 6.77), (' installation', 4.33), (',', 0.99), (' and', 3.94), (' upgrade', 6.14), (' details', 0.76), (',', 0.92), (' see', 1.36), (' the', 7.92), (' files', 13.38), (' RELEASE', 3.14), ('-', 5.45), ('NOT', 0.55), ('ES', 2.99), (',', 3.47), (' INST', 0.0), ('ALL', 3.31), (',', 1.01), (' and', 5.7), (' U', 1.45), ('PG', 0.0), ('R', 0.16), ('ADE', 1.22), ('.', 1.17), ('\n', 1.18), ('</', 0.01), ('p', 0.23), ('><', 0.3), ('ul', 0.26), ('><', 0.03), ('li', 0.05), ('>', 9.57), ('Ready', 0.51), (' to', 3.77), (' get', 0.16), (' started', 0.6), ('?', 3.39), ('\n', 2.73), ('</', 0.01), ('li', 2.94), ('><', 1.27), ('li', 0.09), ('>', 7.51), ('Looking', 0.26), (' for', 3.64), (' the', 6.92), (' technical', 5.61), (' manual', 0.77), ('?', 1.01), ('\n', 0.46), ('<', 2.41), ('ul', 0.83), ('><', 0.04), ('li', 3.7), ('><', 1.45), ('a', 4.4), (' class', 3.38), (':', 5.22), ('external', 11.01), (' free', 5.33), ('>', 4.52), ('https', 0.0), ('://', 1.83), ('www', 0.0), ('.', 1.54), ('media', 0.01), ('wiki', 0.0), ('.', 0.03), ('org', 0.01), ('/', 0.5), ('wiki', 0.01), ('/', 7.81), ('Special', 2.01), (':', 7.34), ('My', 6.13), ('Language', 4.18), ('/', 4.82), ('Man', 0.02), ('ual', 1.61), (':', 5.75), ('Contents', 2.47), ('</', 0.0), ('a', 0.33), ('></', 0.01), ('li', 0.62), ('>', 0.24), ('\n', 0.9), ('</', 0.06), ('ul', 1.37), ('></', 2.05), ('li', 0.9), ('><', 0.55), ('li', 0.84), ('>', 8.19), ('Se', 2.59), ('eking', 1.36), (' help', 3.24), (' from', 2.56), (' a', 6.33), (' person', 2.64), ('?', 0.53), ('\n', 2.06), ('</', 0.02), ('li', 0.22), ('><', 0.01), ('li', 0.39), ('>', 4.15), ('Looking', 1.72), (' to', 7.53), (' file', 0.26), (' a', 2.0), (' bug', 0.51), (' report', 2.72), (' or', 2.99), (' a', 2.0), (' feature', 0.07), (' request', 0.1), ('?', 0.36), ('\n', 1.27), ('</', 0.0), ('li', 0.25), ('><', 0.0), ('li', 0.14), ('>', 4.01), ('Interested', 0.04), (' in', 2.8), (' helping', 1.63), (' out', 1.09), ('?', 0.51), ('\n', 0.71), ('<', 0.37), ('ul', 0.15), ('><', 0.02), ('li', 0.23), ('><', 0.04), ('a', 0.03), (' class', 0.0), (':', 0.74), ('external', 0.13), (' free', 0.06), ('>', 0.18), ('https', 0.0), ('://', 0.75), ('www', 0.0), ('.', 0.06), ('media', 0.0), ('wiki', 0.0), ('.', 0.0), ('org', 0.0), ('/', 0.0), ('wiki', 0.0), ('/', 0.25), ('Special', 0.0), (':', 0.06), ('My', 0.01), ('Language', 0.04), ('/', 6.04), ('How', 2.17), ('_', 0.69), ('to', 0.15), ('_', 8.58), ('cont', 0.02), ('ribute', 0.69), ('</', 0.0), ('a', 0.02), ('></', 0.0), ('li', 0.01), ('>', 0.08), ('\n', 0.35), ('</', 0.0), ('ul', 0.1), ('></', 0.0), ('li', 1.92), ('></', 0.17), ('ul', 1.15), ('><', 0.86), ('p', 0.29), ('>', 3.2), ('Media', 0.02), ('Wiki', 0.52), (' is', 4.19), (' the', 5.1), (' result', 0.0), (' of', 9.6), (' global', 0.78), (' collaboration', 2.29), (' and', 4.17), (' cooperation', 2.75), ('.', 2.48), (' The', 11.16), (' CR', 4.1), ('EDIT', 1.04), ('S', 5.34), (' file', 5.36), (' lists', 7.11), (' technical', 3.95), (' contributors', 1.87), (' to', 0.86), (' the', 0.83), (' project', 1.58), ('.', 1.85), (' The', 4.29), (' COP', 1.31), ('YING', 0.44), (' file', 6.7), (' explains', 9.52), (' Media', 0.01), ('Wiki', 0.43), ("'s", 3.79), (' copyright', 1.42), (' and', 1.26), (' license', 6.3), (' (', 6.01), ('GN', 0.02), ('U', 2.09), (' General', 0.01), (' Public', 0.01), (' License', 3.08), (',', 2.49), (' version', 0.93), (' 2', 2.35), (' or', 0.26), (' later', 0.63), (').', 6.63), (' Many', 3.94), (' thanks', 0.3), (' to', 1.58), (' the', 4.47), (' Wikimedia', 4.8), (' community', 0.48), (' for', 7.53), (' testing', 0.98), (' and', 5.77), (' suggestions', 1.02), ('.', 1.22), ('\n', 0.98), ('</', 0.0), ('p', 2.69), ('></', 0.88), ('div', 1.3), ('></', 0.15), ('div', 1.22), ('></', 0.19), ('div', 1.83), ('>', 1.82), ('<|endoftext|>', 11.63), ('<|endoftext|>', 11.64), ('<|endoftext|>', 11.63), ('<|endoftext|>', 11.63), ('<|endoftext|>', 11.62), ('<|endoftext|>', 11.65), ('<|endoftext|>', 11.63), ('<|endoftext|>', 11.63), ('<|endoftext|>', 11.63), ('<|endoftext|>', 11.63), ('<|endoftext|>', 11.63), ('<|endoftext|>', 11.64), ('<|endoftext|>', 11.64), ('<|endoftext|>', 11.64), ('<|endoftext|>', 11.66), ('<|endoftext|>', 11.65), ('<|endoftext|>', 11.66), ('<|endoftext|>', 11.67), ('<|endoftext|>', 11.68), ('<|endoftext|>', 11.68), ('<|endoftext|>', 11.7), ('<|endoftext|>', 11.69), ('<|endoftext|>', 11.7), ('<|endoftext|>', 11.71), ('<|endoftext|>', 11.74), ('<|endoftext|>', 11.74), ('<|endoftext|>', 11.76), ('<|endoftext|>', 11.77), ('<|endoftext|>', 11.79), ('<|endoftext|>', 11.79), ('<|endoftext|>', 11.81), ('<|endoftext|>', 11.82), ('<|endoftext|>', 11.82), ('<|endoftext|>', 11.83), ('<|endoftext|>', 11.84), ('<|endoftext|>', 11.84), ('<|endoftext|>', 11.85), ('<|endoftext|>', 11.84), ('<|endoftext|>', 11.81), ('<|endoftext|>', 11.78), ('<|endoftext|>', 11.74), ('<|endoftext|>', 11.76), ('<|endoftext|>', 11.81), ('<|endoftext|>', 11.83), ('<|endoftext|>', 11.83), ('<|endoftext|>', 11.82), ('<|endoftext|>', 11.81), ('<|endoftext|>', 11.81), ('<|endoftext|>', 11.81), ('<|endoftext|>', 11.8), ('<|endoftext|>', 11.79), ('<|endoftext|>', 11.79), ('<|endoftext|>', 11.78), ('<|endoftext|>', 11.78), ('<|endoftext|>', 11.77), ('<|endoftext|>', 11.77), ('<|endoftext|>', 11.77), ('<|endoftext|>', 11.76), ('<|endoftext|>', 11.76), ('<|endoftext|>', 11.76), ('<|endoftext|>', 11.75), ('<|endoftext|>', 11.75), ('<|endoftext|>', 11.74), ('<|endoftext|>', 11.75), ('<|endoftext|>', 11.75), ('<|endoftext|>', 11.74), ('<|endoftext|>', 11.74), ('<|endoftext|>', 11.75), ('<|endoftext|>', 11.75), ('<|endoftext|>', 11.74), ('<|endoftext|>', 11.75), ('<|endoftext|>', 11.75), ('<|endoftext|>', 11.75), ('<|endoftext|>', 11.75), ('<|endoftext|>', 11.75), ('<|endoftext|>', 11.76), ('<|endoftext|>', 11.76), ('<|endoftext|>', 11.77), ('<|endoftext|>', 11.77), ('<|endoftext|>', 11.77), ('<|endoftext|>', 11.78), ('<|endoftext|>', 11.78), ('<|endoftext|>', 11.79), ('<|endoftext|>', 11.79), ('<|endoftext|>', 11.8), ('<|endoftext|>', 11.81), ('<|endoftext|>', 11.81), ('<|endoftext|>', 11.82), ('<|endoftext|>', 11.83), ('<|endoftext|>', 11.84), ('<|endoftext|>', 11.84), ('<|endoftext|>', 11.85), ('<|endoftext|>', 11.86), ('<|endoftext|>', 11.86), ('<|endoftext|>', 11.88), ('<|endoftext|>', 11.89), ('<|endoftext|>', 11.89), ('<|endoftext|>', 11.9), ('<|endoftext|>', 11.9), ('<|endoftext|>', 11.92), ('<|endoftext|>', 11.92), ('<|endoftext|>', 11.93), ('<|endoftext|>', 11.94), ('<|endoftext|>', 11.95), ('<|endoftext|>', 11.95), ('<|endoftext|>', 11.96), ('<|endoftext|>', 11.97), ('<|endoftext|>', 11.97), ('<|endoftext|>', 11.98), ('<|endoftext|>', 11.98), ('<|endoftext|>', 11.98), ('<|endoftext|>', 11.99), ('<|endoftext|>', 11.98), ('<|endoftext|>', 11.99), ('<|endoftext|>', 11.99), ('<|endoftext|>', 11.99), ('<|endoftext|>', 12.0), ('<|endoftext|>', 12.0), ('<|endoftext|>', 12.01), ('<|endoftext|>', 12.01), ('<|endoftext|>', 12.01), ('<|endoftext|>', 12.01), ('<|endoftext|>', 12.01), ('<|endoftext|>', 12.02), ('<|endoftext|>', 12.01), ('<|endoftext|>', 12.02), ('<|endoftext|>', 12.02), ('<|endoftext|>', 12.02), ('<|endoftext|>', 12.03), ('<|endoftext|>', 12.03), ('<|endoftext|>', 12.03), ('<|endoftext|>', 12.04), ('<|endoftext|>', 12.04), ('<|endoftext|>', 12.04), ('<|endoftext|>', 12.05), ('<|endoftext|>', 12.05), ('<|endoftext|>', 12.06), ('<|endoftext|>', 12.06), ('<|endoftext|>', 12.06), ('<|endoftext|>', 12.06), ('<|endoftext|>', 12.07), ('<|endoftext|>', 12.08), ('<|endoftext|>', 12.09), ('<|endoftext|>', 12.09), ('<|endoftext|>', 12.11), ('<|endoftext|>', 12.11), ('<|endoftext|>', 12.12), ('<|endoftext|>', 12.13), ('<|endoftext|>', 12.14), ('<|endoftext|>', 12.15), ('<|endoftext|>', 12.16), ('<|endoftext|>', 12.16), ('<|endoftext|>', 12.17), ('<|endoftext|>', 12.18), ('<|endoftext|>', 12.19), ('<|endoftext|>', 12.2), ('<|endoftext|>', 12.2), ('<|endoftext|>', 12.21), ('<|endoftext|>', 12.21), ('<|endoftext|>', 12.22), ('<|endoftext|>', 12.24), ('<|endoftext|>', 12.24), ('<|endoftext|>', 12.25), ('<|endoftext|>', 12.26), ('<|endoftext|>', 12.26), ('<|endoftext|>', 12.27), ('<|endoftext|>', 12.28), ('<|endoftext|>', 12.29), ('<|endoftext|>', 12.3), ('<|endoftext|>', 12.31), ('<|endoftext|>', 12.31), ('<|endoftext|>', 12.32), ('<|endoftext|>', 12.33), ('<|endoftext|>', 12.34), ('<|endoftext|>', 12.35), ('<|endoftext|>', 12.36), ('<|endoftext|>', 12.37), ('<|endoftext|>', 12.38), ('<|endoftext|>', 12.38), ('<|endoftext|>', 12.39), ('<|endoftext|>', 12.4), ('<|endoftext|>', 12.4), ('<|endoftext|>', 12.41), ('<|endoftext|>', 12.41), ('<|endoftext|>', 12.42), ('<|endoftext|>', 12.43), ('<|endoftext|>', 12.44), ('<|endoftext|>', 12.44), ('<|endoftext|>', 12.44), ('<|endoftext|>', 12.45), ('<|endoftext|>', 12.46), ('<|endoftext|>', 12.46), ('<|endoftext|>', 12.47), ('<|endoftext|>', 12.47), ('<|endoftext|>', 12.47), ('<|endoftext|>', 12.48), ('<|endoftext|>', 12.49), ('<|endoftext|>', 12.5), ('<|endoftext|>', 12.5), ('<|endoftext|>', 12.5), ('<|endoftext|>', 12.51), ('<|endoftext|>', 12.52), ('<|endoftext|>', 12.52), ('<|endoftext|>', 12.53), ('<|endoftext|>', 12.53), ('<|endoftext|>', 12.54), ('<|endoftext|>', 12.54), ('<|endoftext|>', 12.54), ('<|endoftext|>', 12.55), ('<|endoftext|>', 12.55), ('<|endoftext|>', 12.55), ('<|endoftext|>', 12.55), ('<|endoftext|>', 12.56), ('<|endoftext|>', 12.55), ('<|endoftext|>', 12.56), ('<|endoftext|>', 12.55), ('<|endoftext|>', 12.55), ('<|endoftext|>', 12.55), ('<|endoftext|>', 12.54), ('<|endoftext|>', 12.54), ('<|endoftext|>', 12.54), ('<|endoftext|>', 12.53), ('<|endoftext|>', 12.52), ('<|endoftext|>', 12.51), ('<|endoftext|>', 12.5), ('<|endoftext|>', 12.49), ('<|endoftext|>', 12.49)]
Normal
[('Media', 10.6), ('Wiki', 7.43), (' 1', 0.34), ('.', 7.53), ('30', 1.39), ('.', 1.29), ('0', 10.81), (' installation', 2.68), ('\n', 18.39), ('Language', 4.49), ('\n', 8.26), ('Ex', 2.11), ('isting', 5.77), (' wiki', 3.11), ('\n', 5.71), ('Welcome', 0.31), (' to', 8.09), (' Media', 0.04), ('Wiki', 3.33), ('!', 1.58), ('\n', 9.95), ('Connect', 1.4), (' to', 9.77), (' database', 2.07), ('\n', 9.05), ('Upgrade', 5.75), (' existing', 5.51), (' installation', 0.69), ('\n', 6.86), ('Database', 6.23), (' settings', 0.58), ('\n', 6.61), ('Name', 2.47), ('\n', 8.8), ('Options', 0.46), ('\n', 5.3), ('Install', 1.97), ('\n', 7.2), ('Complete', 8.17), ('!', 0.89), ('\n', 7.6), ('\n', 6.07), ('Read', 6.15), (' me', 1.46), ('\n', 6.31), ('Media', 0.04), ('Wiki', 3.71), ('\n', 3.91), ('Media', 0.05), ('Wiki', 1.13), (' is', 1.21), (' a', 2.58), (' free', 2.04), (' and', 0.05), (' open', 1.89), ('-', 0.01), ('source', 2.93), (' wiki', 2.66), (' software', 4.88), (' package', 3.15), (' written', 0.39), (' in', 2.83), (' PHP', 0.77), ('.', 1.02), (' It', 6.49), (' serves', 0.24), (' as', 1.62), (' the', 5.96), (' platform', 0.28), (' for', 5.99), (' Wikipedia', 2.63), (' and', 2.75), (' the', 3.91), (' other', 3.17), (' Wikimedia', 1.85), (' projects', 2.3), (',', 6.54), (' used', 1.17), (' by', 4.36), (' hundreds', 0.05), (' of', 1.72), (' millions', 0.15), (' of', 0.5), (' people', 4.72), (' each', 2.2), (' month', 0.24), ('.', 3.4), (' Media', 0.02), ('Wiki', 0.78), (' is', 10.57), (' local', 3.38), ('ised', 3.33), (' in', 6.53), (' over', 5.13), (' 350', 1.9), (' languages', 1.61), (' and', 4.13), (' its', 9.64), (' reliability', 1.49), (' and', 5.33), (' robust', 8.02), (' feature', 0.19), (' set', 4.26), (' have', 4.03), (' earned', 0.25), (' it', 1.21), (' a', 4.69), (' large', 3.86), (' and', 5.49), (' vibrant', 0.73), (' community', 1.74), (' of', 9.95), (' third', 0.79), ('-', 0.05), ('party', 1.47), (' users', 2.38), (' and', 2.15), (' developers', 0.22), ('.', 0.88), ('\n', 12.51), ('feature', 3.19), ('-', 4.64), ('rich', 3.35), (' and', 5.51), (' ext', 0.03), ('ensible', 4.34), (',', 6.06), (' both', 4.6), (' on', 2.37), ('-', 5.34), ('wiki', 0.32), (' and', 5.84), (' with', 9.08), (' hundreds', 0.03), (' of', 4.55), (' extensions', 5.79), (';', 1.58), ('\n', 9.72), ('sc', 3.16), ('al', 0.68), ('able', 2.43), (' and', 8.54), (' suitable', 0.35), (' for', 3.37), (' both', 5.07), (' small', 0.55), (' and', 0.26), (' large', 3.56), (' sites', 1.16), (';', 0.05), ('\n', 6.38), ('simple', 2.14), (' to', 2.97), (' install', 1.25), (',', 6.52), (' working', 1.63), (' on', 4.1), (' most', 6.96), (' hardware', 5.02), ('/', 0.43), ('software', 5.06), (' combinations', 0.6), (';', 3.34), (' and', 0.46), ('\n', 3.54), ('available', 1.96), (' in', 6.81), (' your', 2.49), (' language', 1.54), ('.', 0.48), ('\n', 4.78), ('For', 8.32), (' system', 1.7), (' requirements', 0.98), (',', 6.28), (' installation', 4.69), (',', 1.16), (' and', 4.29), (' upgrade', 5.27), (' details', 0.78), (',', 0.94), (' see', 1.27), (' the', 8.17), (' files', 13.17), (' RELEASE', 3.16), ('-', 5.36), ('NOT', 0.64), ('ES', 2.92), (',', 3.46), (' INST', 0.0), ('ALL', 3.02), (',', 0.93), (' and', 5.68), (' U', 1.84), ('PG', 0.0), ('R', 0.2), ('ADE', 0.91), ('.', 0.36), ('\n', 8.33), ('Ready', 0.74), (' to', 2.98), (' get', 0.15), (' started', 0.28), ('?', 0.7), ('\n', 7.21), ('Looking', 0.21), (' for', 3.01), (' the', 7.27), (' technical', 5.33), (' manual', 0.82), ('?', 1.22), ('\n', 8.08), ('https', 0.0), ('://', 2.16), ('www', 0.0), ('.', 0.58), ('media', 0.01), ('wiki', 0.0), ('.', 0.05), ('org', 0.01), ('/', 0.38), ('wiki', 0.0), ('/', 7.89), ('Special', 2.66), (':', 7.12), ('My', 6.45), ('Language', 3.68), ('/', 4.87), ('Man', 0.03), ('ual', 2.94), (':', 6.07), ('Contents', 2.01), ('\n', 7.69), ('Se', 3.03), ('eking', 1.58), (' help', 3.18), (' from', 2.6), (' a', 6.32), (' person', 2.25), ('?', 0.64), ('\n', 5.43), ('Looking', 1.94), (' to', 7.65), (' file', 0.37), (' a', 0.73), (' bug', 0.93), (' report', 2.8), (' or', 3.44), (' a', 1.64), (' feature', 0.12), (' request', 0.12), ('?', 0.38), ('\n', 5.8), ('Interested', 0.13), (' in', 2.95), (' helping', 1.69), (' out', 0.79), ('?', 0.62), ('\n', 3.99), ('https', 0.0), ('://', 2.07), ('www', 0.0), ('.', 0.36), ('media', 0.0), ('wiki', 0.0), ('.', 0.0), ('org', 0.0), ('/', 0.01), ('wiki', 0.0), ('/', 1.21), ('Special', 0.05), (':', 0.15), ('My', 0.04), ('Language', 0.1), ('/', 5.32), ('How', 2.06), ('_', 0.8), ('to', 0.71), ('_', 8.56), ('cont', 0.01), ('ribute', 1.09), ('\n', 3.63), ('Media', 0.03), ('Wiki', 1.01), (' is', 4.05), (' the', 5.23), (' result', 0.01), (' of', 9.91), (' global', 0.89), (' collaboration', 2.25), (' and', 3.91), (' cooperation', 2.92), ('.', 2.62), (' The', 10.57), (' CR', 3.93), ('EDIT', 1.12), ('S', 4.81), (' file', 5.67), (' lists', 6.98), (' technical', 4.13), (' contributors', 1.87), (' to', 0.82), (' the', 0.77), (' project', 1.45), ('.', 2.09), (' The', 4.95), (' COP', 1.02), ('YING', 0.54), (' file', 6.89), (' explains', 9.13), (' Media', 0.0), ('Wiki', 0.51), ("'s", 3.35), (' copyright', 1.45), (' and', 1.18), (' license', 6.25), (' (', 5.91), ('GN', 0.03), ('U', 2.08), (' General', 0.01), (' Public', 0.01), (' License', 2.86), (',', 2.62), (' version', 0.93), (' 2', 2.22), (' or', 0.29), (' later', 0.65), (').', 6.31), (' Many', 3.74), (' thanks', 0.3), (' to', 1.68), (' the', 4.68), (' Wikimedia', 4.66), (' community', 0.57), (' for', 7.79), (' testing', 0.96), (' and', 5.76), (' suggestions', 0.91), ('.', 0.85)]
```
